### PR TITLE
IiifController#image_info: specify 'maxWidth' in 'profile' property when image is not downloadable

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -106,7 +106,12 @@ class IiifController < ApplicationController
       end
     end
 
-    info['profile'] = 'http://iiif.io/api/image/2/level1'
+    info['profile'] =
+      if can? :download, current_image
+        'http://iiif.io/api/image/2/level1'
+      else
+        ['http://iiif.io/api/image/2/level1', { 'maxWidth' => 400 }]
+      end
 
     info['sizes'] = [{ width: 400, height: 400 }] unless current_image.maybe_downloadable?
 


### PR DESCRIPTION
fix existing tests:  pull a more generally applicable `allow` out of the individual tile size test case and put it in a `before` in the `#metadata` section, so that all of those test cases are for downloadable images by default (previously didn't matter one way or the other for the extant profile test case, but matters now with this change).  add a test case that looks for `maxWidth` in `profile` when the image isn't downloadable.

closes #134