### PR TITLE
Implement IIIF Auth 1.0 tiered access by redirecting to degraded info.json documents

### DIFF
--- a/app/models/concerns/stacks_rights.rb
+++ b/app/models/concerns/stacks_rights.rb
@@ -82,11 +82,7 @@ module StacksRights
   private
 
   def rights_xml
-    Rails.cache.fetch("stacks_file/#{druid}-#{etag}/rights_xml", expires_in: 10.minutes) do
-      benchmark "Fetching public xml for #{druid}" do
-        Faraday.get(Settings.purl.url + "/#{druid}.xml").body
-      end
-    end
+    Purl.public_xml(druid, etag)
   end
 
   def logger

--- a/app/models/purl.rb
+++ b/app/models/purl.rb
@@ -1,0 +1,30 @@
+# PURL API service
+class Purl
+  include ActiveSupport::Benchmarkable
+
+  def self.instance
+    @purl ||= new
+  end
+
+  class << self
+    delegate :public_xml, to: :instance
+  end
+
+  def public_xml(druid, etag)
+    Rails.cache.fetch("purl/#{druid}-#{etag}/public_xml", expires_in: 10.minutes) do
+      benchmark "Fetching public xml for #{druid}" do
+        Faraday.get(public_xml_url(druid)).body
+      end
+    end
+  end
+
+  private
+
+  def public_xml_url(druid)
+    Settings.purl.url + "#{druid}.xml"
+  end
+
+  def logger
+    Rails.logger
+  end
+end

--- a/spec/fixtures/rights_xml_fixtures.rb
+++ b/spec/fixtures/rights_xml_fixtures.rb
@@ -12,4 +12,18 @@ module RightsXMLFixtures
       </publicObject>
     XML
   end
+
+  def stanford_restricted_rights_xml
+    <<-XML
+      <publicObject>
+        <rightsMetadata>
+          <access type="read">
+            <machine>
+              <group>Stanford</group>
+            </machine>
+          </access>
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
 end

--- a/spec/models/purl_spec.rb
+++ b/spec/models/purl_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Purl do
+  before(:each) do
+    Rails.cache.clear
+  end
+
+  describe '.public_xml' do
+    it 'fetches the public xml' do
+      allow(Faraday).to receive(:get).with('https://purl.stanford.edu/abc.xml').and_return(double(body: ''))
+
+      described_class.public_xml('abc', '123')
+
+      expect(Faraday).to have_received(:get).with('https://purl.stanford.edu/abc.xml')
+    end
+  end
+end

--- a/spec/support/stub_rights_xml.rb
+++ b/spec/support/stub_rights_xml.rb
@@ -5,9 +5,7 @@
 # are not stubbing a 3rd party class.
 module StubRightsXML
   def stub_rights_xml(xml)
-    allow(HTTP).to receive(:get).and_return(
-      instance_double(HTTP::Response, body: xml)
-    )
+    allow(Purl).to receive(:public_xml).and_return(xml)
   end
 end
 


### PR DESCRIPTION
We should manually test this with sul-embed just to make sure it is ok with the redirects.