### PR TITLE
adds a confirmLabel to our IIIF auth responses

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -128,6 +128,7 @@ class IiifController < ApplicationController
           '@id' => iiif_auth_api_url,
           'profile' => 'http://iiif.io/api/auth/1/login',
           'label' => 'Stanford-affiliated? Login to view',
+          'confirmLabel' => 'Login',
           'service' => [
             {
               '@id' => iiif_token_api_url,
@@ -146,6 +147,7 @@ class IiifController < ApplicationController
         services << {
           'profile' => 'http://iiif.io/api/auth/1/external',
           'label' => 'External Authentication Required',
+          'confirmLabel' => 'Login',
           'failureHeader' => 'Restricted Material',
           'failureDescription' => 'Restricted content cannot be accessed from your location',
           'service' => [

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -193,6 +193,7 @@ describe IiifController do
 
           expect(auth_service['service'].first['profile']).to eq 'http://iiif.io/api/auth/1/token'
           expect(auth_service['service'].first['@id']).to eq iiif_token_api_url
+          expect(auth_service['confirmLabel']).to eq 'Login'
         end
 
         it 'advertises a logout service' do
@@ -216,6 +217,7 @@ describe IiifController do
           expect(location_service).to be_present
           expect(location_service['profile']).to eq 'http://iiif.io/api/auth/1/external'
           expect(location_service['label']).to eq 'External Authentication Required'
+          expect(location_service['confirmLabel']).to eq 'Login'
           expect(location_service['failureHeader']).to eq 'Restricted Material'
           expect(location_service['failureDescription']).to eq location_restriction_msg
           expect(location_service['service'].first['profile']).to eq 'http://iiif.io/api/auth/1/token'


### PR DESCRIPTION
UV currently does not have a fallback confirmLabel for its login dialog (see https://github.com/UniversalViewer/universalviewer/issues/484)

Without this, SUL resources in UV render "undefined" label:

<img width="189" alt="screen shot 2017-07-31 at 3 27 00 pm" src="https://user-images.githubusercontent.com/1656824/28801442-7371fc72-7606-11e7-95be-148ab70b3417.png">
