### PR TITLE
allows for a content-disposition of attachment with a "download" file…

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -12,13 +12,18 @@ class FileController < ApplicationController
     authorize! :read, current_file
     expires_in 10.minutes
 
-    send_file current_file.path, disposition: :inline
+    send_file current_file.path, disposition: disposition
   end
 
   private
 
+  def disposition
+    return :attachment if allowed_params[:download]
+    :inline
+  end
+
   def allowed_params
-    params.permit(:id, :file_name)
+    params.permit(:id, :file_name, :download)
   end
   # the args needed for StacksFile.new happen to be the same as allowed_params
   alias stacks_file_params allowed_params

--- a/app/models/stacks_file.rb
+++ b/app/models/stacks_file.rb
@@ -5,7 +5,7 @@ class StacksFile
   include ActiveSupport::Benchmarkable
   include StacksRights
 
-  attr_accessor :id, :file_name, :current_ability
+  attr_accessor :id, :file_name, :current_ability, :download
 
   def exist?
     file_exist?

--- a/spec/controllers/file_controller_spec.rb
+++ b/spec/controllers/file_controller_spec.rb
@@ -20,6 +20,11 @@ describe FileController do
       subject
     end
 
+    it 'sets disposition attachment with download param' do
+      expect(controller).to receive(:send_file).with(file.path, disposition: :attachment).and_call_original
+      get :show, params: { id: 'xf680rd3068', file_name: 'xf680rd3068_1.jp2', download: 'any' }
+    end
+
     context 'additional params' do
       subject do
         get :show, params: { id: 'xf680rd3068', file_name: 'xf680rd3068_1.jp2', ignored: 'ignored', host: 'host' }


### PR DESCRIPTION
… param

Originally reported in https://github.com/sul-dlss/sul-embed/issues/796

Based off of https://github.com/sul-dlss/stacks/commit/1cf73219d648a9c0324057097097ff7b6cc706da

and https://github.com/sul-dlss/sul-embed/issues/768

Previously needed for UV to have inline disposition for viewing PDF's, this now allows for `attachment` disposition.