### PR TITLE
Supports the use case where if an image is not accessible

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -4,6 +4,8 @@ class IiifController < ApplicationController
   before_action :load_image
   before_action :add_iiif_profile_header
 
+  THUMBNAIL_LONGEDGE_MAX = 400
+
   rescue_from ActionController::MissingFile do
     render plain: 'File not found', status: :not_found
   end
@@ -101,6 +103,7 @@ class IiifController < ApplicationController
     @image ||= StacksImage.new(stacks_image_params.merge(current_ability: current_ability))
   end
 
+  # rubocop:disable Metrics/MethodLength
   def image_info
     info = current_image.info do |md|
       if can? :download, current_image
@@ -112,14 +115,35 @@ class IiifController < ApplicationController
       end
     end
 
+    ##
+    # This is an incredibly horrible hack which forces us to be at the mercy of
+    # implementation details of a IIIF client. When we are in a degraded state,
+    # we are giving back resized width/height so that a viewer can appropriately
+    # display the degraded view.
+    unless can? :access, current_image
+      dimmensions = [current_image.image_width.to_f, current_image.image_height.to_f]
+      max = dimmensions.max
+      min = dimmensions.min
+      scale = min / max
+      h_scale = max == dimmensions.last ? 1 : scale
+      w_scale = max == dimmensions.first ? 1 : scale
+      info['height'] = (THUMBNAIL_LONGEDGE_MAX * h_scale).ceil
+      info['width'] = (THUMBNAIL_LONGEDGE_MAX * w_scale).ceil
+    end
+
     info['profile'] =
       if can? :download, current_image
         'http://iiif.io/api/image/2/level1'
       else
-        ['http://iiif.io/api/image/2/level1', { 'maxWidth' => 400 }]
+        ['http://iiif.io/api/image/2/level1', { 'maxWidth' => THUMBNAIL_LONGEDGE_MAX }]
       end
 
-    info['sizes'] = [{ width: 400, height: 400 }] unless current_image.maybe_downloadable?
+    unless current_image.maybe_downloadable?
+      info['sizes'] = [{
+        width: THUMBNAIL_LONGEDGE_MAX,
+        height: THUMBNAIL_LONGEDGE_MAX
+      }]
+    end
 
     services = []
     if anonymous_ability.cannot? :download, current_image
@@ -173,6 +197,7 @@ class IiifController < ApplicationController
 
     info
   end
+  # rubocop:enable Metrics/MethodLength
 
   def stacks_image_params
     allowed_params.slice(:region, :size, :rotation, :quality, :format).merge(identifier_params).merge(canonical_params)

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -35,6 +35,10 @@ class StubMetadataObject
   def restricted_locations
     []
   end
+
+  def image_width; end
+
+  def image_height; end
 end
 
 describe IiifController do
@@ -163,6 +167,7 @@ describe IiifController do
       context 'when the image is downloadable' do
         before do
           allow(controller).to receive(:can?).with(:download, stub_metadata_object).and_return(true)
+          allow(controller).to receive(:can?).with(:access, stub_metadata_object).and_return(true)
           allow(controller.send(:anonymous_ability)).to receive(:can?)
             .with(:download, stub_metadata_object).and_return(true)
         end
@@ -211,6 +216,25 @@ describe IiifController do
           expect(logout_service['profile']).to eq 'http://iiif.io/api/auth/1/logout'
           expect(logout_service['@id']).to eq logout_url
           expect(logout_service['label']).to eq 'Logout'
+        end
+      end
+
+      context 'when the image is not accessible' do
+        context 'width > height' do
+          it 'tile height/width' do
+            expect(stub_metadata_object).to receive(:image_width).and_return 1600
+            expect(stub_metadata_object).to receive(:image_height).and_return 400
+            expect(image_info['height']).to eq 100
+            expect(image_info['width']).to eq 400
+          end
+        end
+        context 'height > width' do
+          it 'tile height/width' do
+            expect(stub_metadata_object).to receive(:image_width).and_return 400
+            expect(stub_metadata_object).to receive(:image_height).and_return 1600
+            expect(image_info['height']).to eq 400
+            expect(image_info['width']).to eq 100
+          end
         end
       end
 

--- a/spec/requests/iiif_spec.rb
+++ b/spec/requests/iiif_spec.rb
@@ -6,7 +6,14 @@ RSpec.describe 'IIIF API' do
   end
 
   before do
-    allow(stacks_image).to receive_messages(exist?: true, etag: 'etag', mtime: Time.zone.now, info: {})
+    allow(stacks_image).to receive_messages(
+      exist?: true,
+      etag: 'etag',
+      mtime: Time.zone.now,
+      info: {},
+      image_width: 0,
+      image_height: 0
+    )
     allow(StacksImage).to receive(:new).with(hash_including(id: 'nr349ct7889', file_name: 'nr349ct7889_00_0001'))
       .and_return(stacks_image)
   end


### PR DESCRIPTION
When an image is not accessible, its height/width should be scaled
to a max dimension of 400px.

Closes https://github.com/sul-dlss/sul-embed/issues/803
Closes https://github.com/sul-dlss/sul-embed/issues/808