### PR TITLE
Revert "Supports the use case where if an image is not accessible"

### DIFF
--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -35,10 +35,6 @@ class StubMetadataObject
   def restricted_locations
     []
   end
-
-  def image_width; end
-
-  def image_height; end
 end
 
 describe IiifController do
@@ -167,7 +163,6 @@ describe IiifController do
       context 'when the image is downloadable' do
         before do
           allow(controller).to receive(:can?).with(:download, stub_metadata_object).and_return(true)
-          allow(controller).to receive(:can?).with(:access, stub_metadata_object).and_return(true)
           allow(controller.send(:anonymous_ability)).to receive(:can?)
             .with(:download, stub_metadata_object).and_return(true)
         end
@@ -216,25 +211,6 @@ describe IiifController do
           expect(logout_service['profile']).to eq 'http://iiif.io/api/auth/1/logout'
           expect(logout_service['@id']).to eq logout_url
           expect(logout_service['label']).to eq 'Logout'
-        end
-      end
-
-      context 'when the image is not accessible' do
-        context 'width > height' do
-          it 'tile height/width' do
-            expect(stub_metadata_object).to receive(:image_width).and_return 1600
-            expect(stub_metadata_object).to receive(:image_height).and_return 400
-            expect(image_info['height']).to eq 100
-            expect(image_info['width']).to eq 400
-          end
-        end
-        context 'height > width' do
-          it 'tile height/width' do
-            expect(stub_metadata_object).to receive(:image_width).and_return 400
-            expect(stub_metadata_object).to receive(:image_height).and_return 1600
-            expect(image_info['height']).to eq 400
-            expect(image_info['width']).to eq 100
-          end
         end
       end
 

--- a/spec/requests/iiif_spec.rb
+++ b/spec/requests/iiif_spec.rb
@@ -6,14 +6,7 @@ RSpec.describe 'IIIF API' do
   end
 
   before do
-    allow(stacks_image).to receive_messages(
-      exist?: true,
-      etag: 'etag',
-      mtime: Time.zone.now,
-      info: {},
-      image_width: 0,
-      image_height: 0
-    )
+    allow(stacks_image).to receive_messages(exist?: true, etag: 'etag', mtime: Time.zone.now, info: {})
     allow(StacksImage).to receive(:new).with(hash_including(id: 'nr349ct7889', file_name: 'nr349ct7889_00_0001'))
       .and_return(stacks_image)
   end


### PR DESCRIPTION
This reverts commit a858ca755be051d2894aa8c973c2f0006c85f22f.

This doesn't approach doesn't play nice with our ImageX viewer, resulting in the "wrong" tiles being loaded.