### PR TITLE
[WIP] Extract DjatokaAdapter into a class for dynamic loading

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ AllCops:
 
 Rails:
   Enabled: true
+  
+Metrics/ClassLength:
+  Max: 118
 
 Metrics/LineLength:
   Max: 120

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,12 +10,6 @@
 Metrics/AbcSize:
   Max: 79
 
-# Offense count: 1
-# Configuration parameters: CountComments.
-Metrics/ClassLength:
-  Exclude:
-    - 'app/controllers/iiif_controller.rb'
-
 # Offense count: 2
 Metrics/CyclomaticComplexity:
   Max: 23

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ end
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', require: false
+  gem 'byebug'
 
   # Call 'binding.pry' anywhere in the code to stop execution and get a pry console
   gem 'pry-byebug', require: false

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -102,71 +102,21 @@ class IiifController < ApplicationController
   end
 
   def load_image
-    @image ||= model.new(stacks_image_params.merge(current_ability: current_ability))
+    @image ||= begin
+                 img = model.new(stacks_image_params)
+                 can?(:download, img) ? img : img.restricted
+               end
   end
 
   def image_info
-    info = current_image.info do |md|
-      if can? :download, current_image
-        md.tile_width = 1024
-        md.tile_height = 1024
-      else
-        md.tile_width = 256
-        md.tile_height = 256
-      end
-    end
-
-    info['profile'] =
-      if can? :download, current_image
-        'http://iiif.io/api/image/2/level1'
-      else
-        ['http://iiif.io/api/image/2/level1', { 'maxWidth' => 400 }]
-      end
-
+    info = current_image.info
+    info['profile'] = current_image.profile
     info['sizes'] = [{ width: 400, height: 400 }] unless current_image.maybe_downloadable?
 
     services = []
     if anonymous_ability.cannot? :download, current_image
-      if current_image.stanford_restricted?
-        services << {
-          '@context' => 'http://iiif.io/api/auth/1/context.json',
-          '@id' => iiif_auth_api_url,
-          'profile' => 'http://iiif.io/api/auth/1/login',
-          'label' => 'Log in to access all available features.',
-          'confirmLabel' => 'Login',
-          'failureHeader' => 'Unable to authenticate',
-          'failureDescription' => 'The authentication service cannot be reached'\
-            '. If your browser is configured to block pop-up windows, try allow'\
-            'ing pop-up windows for this site before attempting to log in again.',
-          'service' => [
-            {
-              '@id' => iiif_token_api_url,
-              'profile' => 'http://iiif.io/api/auth/1/token'
-            },
-            {
-              '@id' => logout_url,
-              'profile' => 'http://iiif.io/api/auth/1/logout',
-              'label' => 'Logout'
-            }
-          ]
-        }
-      end
-
-      if current_image.restricted_by_location?
-        services << {
-          '@context' => 'http://iiif.io/api/auth/1/context.json',
-          'profile' => 'http://iiif.io/api/auth/1/external',
-          'label' => 'External Authentication Required',
-          'failureHeader' => 'Restricted Material',
-          'failureDescription' => 'Restricted content cannot be accessed from your location',
-          'service' => [
-            {
-              '@id' => iiif_token_api_url,
-              'profile' => 'http://iiif.io/api/auth/1/token'
-            }
-          ]
-        }
-      end
+      services << AuthService.to_iiif(self) if current_image.stanford_restricted?
+      services << LocationService.to_iiif(self) if current_image.restricted_by_location?
     end
 
     if services.one?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -50,6 +50,8 @@ class Ability
       f.location_downloadable?(user.location)
     end
 
+    cannot :download, RestrictedImage
+
     can :read, [StacksFile, StacksImage, StacksMediaStream] do |f|
       can? :download, f
     end

--- a/app/models/concerns/backed_by_file.rb
+++ b/app/models/concerns/backed_by_file.rb
@@ -11,5 +11,5 @@ module BackedByFile
   end
 
   delegate :id, :id=, :file_name, :file_name=, :etag, :druid, :mtime,
-           :current_ability, :current_ability=, to: :file
+           to: :file
 end

--- a/app/models/concerns/djatoka_adapter.rb
+++ b/app/models/concerns/djatoka_adapter.rb
@@ -11,7 +11,8 @@ module DjatokaAdapter
     end
   end
 
-  def info(&block)
+  # The block gets passed to https://github.com/jronallo/djatoka/blob/master/lib/djatoka/metadata.rb#L98
+  def djatoka_info(&block)
     metadata.as_json(&block)
   end
 
@@ -56,7 +57,7 @@ module DjatokaAdapter
   end
 
   def djatoka_path
-    "file://#{file.path}"
+    "file://#{path}"
   end
 
   def resolver

--- a/app/models/concerns/image_adapter.rb
+++ b/app/models/concerns/image_adapter.rb
@@ -1,0 +1,7 @@
+# Module for storing a configurable Image Server Resolver
+module ImageAdapter
+  # Resolver class allows catching the endpoint for the Image Server
+  class Resolver
+    class_attribute :endpoint
+  end
+end

--- a/app/models/djatoka_image.rb
+++ b/app/models/djatoka_image.rb
@@ -1,0 +1,54 @@
+##
+# Djatoka-backed implementation of StacksImage delivery
+class DjatokaImage
+  include ActiveModel::Model
+  include ActiveSupport::Benchmarkable
+
+  attr_accessor :path, :canonical_url, :size, :region, :rotation, :quality, :format
+
+  # @return [Djatoka::Metadata] the image metadata
+  def metadata
+    @metadata ||= Rails.cache.fetch("djatoka/metadata/#{djatoka_path}", expires_in: 10.minutes) do
+      fetch_metadata
+    end
+  end
+
+  def display_region
+    @display_region ||= fetch_region
+  end
+
+  private
+
+  # @return [Djatoka::Metadata]
+  def fetch_metadata
+    with_retries(max_tries: 3, rescue: exceptions_to_retry) do
+      benchmark "Fetching djatoka metadata for #{djatoka_path}" do
+        ImageAdapter::Resolver.endpoint.metadata(djatoka_path).perform
+      end
+    end
+  end
+
+  def fetch_region
+    @fetch_region ||= with_retries(max_tries: 3, rescue: exceptions_to_retry) do
+      iiif_req = Djatoka::IiifRequest.new(ImageAdapter::Resolver.endpoint, djatoka_path)
+      iiif_req.region(region)
+              .size(size)
+              .rotation(rotation)
+              .quality(quality)
+              .format(format)
+              .djatoka_region
+    end
+  end
+
+  def djatoka_path
+    "file://#{path}"
+  end
+
+  def logger
+    Rails.logger
+  end
+
+  def exceptions_to_retry
+    [Errno::ECONNRESET, Errno::ECONNREFUSED, Net::ReadTimeout]
+  end
+end

--- a/app/models/djatoka_metadata.rb
+++ b/app/models/djatoka_metadata.rb
@@ -35,7 +35,7 @@ class DjatokaMetadata
     metadata.height.to_i
   end
 
-  # return the image metadata
+  # @return [Djatoka::Metadata] the image metadata
   def metadata
     @metadata ||= Rails.cache.fetch("djatoka/metadata/#{@stacks_file_path}", expires_in: 10.minutes) do
       fetch_metadata
@@ -44,6 +44,7 @@ class DjatokaMetadata
 
   private
 
+  # @return [Djatoka::Metadata]
   def fetch_metadata
     with_retries(max_tries: 3, rescue: exceptions_to_retry) do
       benchmark "Fetching djatoka metadata for #{@stacks_file_path}" do

--- a/app/models/restricted_image.rb
+++ b/app/models/restricted_image.rb
@@ -1,0 +1,22 @@
+# The type of image that is used if a user doesn't have
+# `can? :download, stacks_image' permissions
+class RestrictedImage < StacksImage
+  # TODO: remove tight coupling to djatoka
+  # @return [Mash]
+  def info
+    djatoka_info do |md|
+      md.tile_width = 256
+      md.tile_height = 256
+    end
+  end
+
+  def profile
+    ["http://iiif.io/api/image/2/level1", { "maxWidth" => 400 }]
+  end
+
+  # Overides stacks image to provide fixed dimensions
+  def max_tile_dimensions
+    return explicit_tile_dimensions('!512,512') if region =~ /^(\d+),(\d+),(\d+),(\d+)$/
+    explicit_tile_dimensions('!400,400')
+  end
+end

--- a/app/models/stacks_file.rb
+++ b/app/models/stacks_file.rb
@@ -25,9 +25,7 @@ class StacksFile
 
   def path
     @path ||= begin
-      match = druid.match(/^([a-z]{2})(\d{3})([a-z]{2})(\d{4})$/i)
-
-      File.join(Settings.stacks.storage_root, match[1], match[2], match[3], match[4], file_name) if match && file_name
+      PathService.for(druid, file_name)
     end
   end
 

--- a/app/services/auth_service.rb
+++ b/app/services/auth_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Produces iiif services for authenticating
+class AuthService
+  # helper method to create a new auth service
+  # @param context [IiifController] a controller context used to make url helpers
+  def self.to_iiif(context)
+    new(context).to_iiif
+  end
+
+  # @param context [IiifController] a controller context used to make url helpers
+  def initialize(context)
+    @context = context
+  end
+
+  def to_iiif
+    {
+      '@context' => 'http://iiif.io/api/auth/1/context.json',
+      '@id' => iiif_auth_api_url,
+      'profile' => 'http://iiif.io/api/auth/1/login',
+      'label' => 'Log in to access all available features.',
+      'confirmLabel' => 'Login',
+      'failureHeader' => 'Unable to authenticate',
+      'failureDescription' => 'The authentication service cannot be reached'\
+        '. If your browser is configured to block pop-up windows, try allow'\
+        'ing pop-up windows for this site before attempting to log in again.',
+      'service' => [
+        {
+          '@id' => iiif_token_api_url,
+          'profile' => 'http://iiif.io/api/auth/1/token'
+        },
+        {
+          '@id' => logout_url,
+          'profile' => 'http://iiif.io/api/auth/1/logout',
+          'label' => 'Logout'
+        }
+      ]
+    }
+  end
+
+  delegate :iiif_auth_api_url, :logout_url, :iiif_token_api_url, to: :url_helpers
+
+  def url_helpers
+    @context
+  end
+end

--- a/app/services/location_service.rb
+++ b/app/services/location_service.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Produces iiif service for location based access
+class LocationService
+  # helper method to create a new location service
+  # @param context [IiifController] a controller context used to make url helpers
+  def self.to_iiif(context)
+    new(context).to_iiif
+  end
+
+  # @param context [IiifController] a controller context used to make url helpers
+  def initialize(context)
+    @context = context
+  end
+
+  def to_iiif
+    {
+      '@context' => 'http://iiif.io/api/auth/1/context.json',
+      'profile' => 'http://iiif.io/api/auth/1/external',
+      'label' => 'External Authentication Required',
+      'failureHeader' => 'Restricted Material',
+      'failureDescription' => 'Restricted content cannot be accessed from your location',
+      'service' => [
+        {
+          '@id' => iiif_token_api_url,
+          'profile' => 'http://iiif.io/api/auth/1/token'
+        }
+      ]
+    }
+  end
+
+  delegate :iiif_token_api_url, to: :url_helpers
+
+  def url_helpers
+    @context
+  end
+end

--- a/app/services/path_service.rb
+++ b/app/services/path_service.rb
@@ -1,0 +1,8 @@
+# Converts druids/file name to a file path on disk
+module PathService
+  def self.for(druid, file_name)
+    match = druid.match(/^([a-z]{2})(\d{3})([a-z]{2})(\d{4})$/i)
+
+    File.join(Settings.stacks.storage_root, match[1], match[2], match[3], match[4], file_name) if match && file_name
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   config.active_support.deprecation = :log
 
   # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  # config.active_record.migration_error = :page_load
 
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large

--- a/config/initializers/image_adapter.rb
+++ b/config/initializers/image_adapter.rb
@@ -1,0 +1,1 @@
+ImageAdapter::Resolver.endpoint = Djatoka::Resolver.new(Settings.stacks.djatoka.url)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -26,6 +26,6 @@ OkComputer::Registry.register 'purl_url', OkComputer::HttpCheck.new(Settings.pur
 #   - in /status/all, these checks will display their result text, but will not affect HTTP response code
 
 # For image content in image viewer
-djatoka_url_to_check = Settings.stacks.djatoka_url + '?rft_id=/&svc_id=info:lanl-repo/svc/ping&url_ver=Z39.88-2004'
+djatoka_url_to_check = Settings.stacks.djatoka.url + '?rft_id=/&svc_id=info:lanl-repo/svc/ping&url_ver=Z39.88-2004'
 OkComputer::Registry.register 'imageserver_url', OkComputer::HttpCheck.new(djatoka_url_to_check)
 OkComputer.make_optional %w(imageserver_url)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,9 @@
 stacks:
   storage_root: /stacks
-  djatoka_url: 'http://localhost:8080/resolver'
+  driver: djatoka
+  djatoka:
+    image: DjatokaImage
+    url: 'http://localhost:8080/resolver'
 
 purl:
   url: 'https://purl.stanford.edu/'

--- a/spec/models/restricted_image_spec.rb
+++ b/spec/models/restricted_image_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe RestrictedImage do
+  let(:instance) { described_class.new }
+
+  describe '#info' do
+    subject { instance.info }
+
+    before do
+      instance.define_singleton_method :djatoka_info do |&block|
+        opts = OpenStruct.new
+        block.call(opts)
+        opts.to_h
+      end
+    end
+
+    it "adds tile size to the djatoka response" do
+      expect(subject[:tile_height]).to eq 256
+      expect(subject[:tile_width]).to eq 256
+    end
+  end
+
+  describe '#profile' do
+    subject { instance.profile }
+
+    it { is_expected.to eq ['http://iiif.io/api/image/2/level1', { 'maxWidth' => 400 }] }
+  end
+
+  describe '#tile_dimensions' do
+    subject { instance.tile_dimensions }
+
+    before do
+      instance.size = 'max'
+    end
+
+    context "full region" do
+      before do
+        instance.region = 'full'
+      end
+
+      it 'limits users to thumbnail sizes' do
+        expect(subject).to eq [400, 400]
+      end
+    end
+
+    context "specified region" do
+      before do
+        instance.region = '0,0,800,600'
+      end
+
+      it 'limits users to a maximum tiles size' do
+        expect(subject).to eq [512, 512]
+      end
+    end
+  end
+end

--- a/spec/requests/iiif_spec.rb
+++ b/spec/requests/iiif_spec.rb
@@ -1,14 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'IIIF API' do
-  let(:stacks_image) do
-    StacksImage.new
-  end
-
   before do
-    allow(stacks_image).to receive_messages(exist?: true, etag: 'etag', mtime: Time.zone.now, info: {})
-    allow(StacksImage).to receive(:new).with(hash_including(id: 'nr349ct7889', file_name: 'nr349ct7889_00_0001'))
-      .and_return(stacks_image)
+    allow_any_instance_of(StacksImage).to receive_messages(exist?: true, etag: 'etag', mtime: Time.zone.now, djatoka_info: {})
   end
 
   it 'redirects base uri requests to the info.json document' do


### PR DESCRIPTION
Here is a first pass at pulling the DjatokaAdapter stuff into a class that can be called dynamically based on the the configuration, a few notes (and will add comments inline)

- Updates settings.yml to set a "driver", resolver and image class based on the driver.
- Sets the Image service resolver based on settings in an initializer
- Pulls some of the work into StacksImage so that the DjatokaImage is only used to load the image and metadata
- This is making the assumption that other image servers (RIIIF/Cantaloupe) will require a persistent resolver available.

TODO:

- Document settings.yml
- Document DjatokaImage requirements in order to create CantaloupeImage and/or RiiifImage
- Write tests and perform more complete tests against a wider range of image and metadata requests.