### PR TITLE
Move djatoka_url in settings to driver.image.attributes.url

### DIFF
--- a/app/models/djatoka_image.rb
+++ b/app/models/djatoka_image.rb
@@ -50,7 +50,7 @@ class DjatokaImage < SourceImage
   end
 
   def resolver
-    @resolver ||= Djatoka::Resolver.new(Settings.stacks.djatoka_url)
+    @resolver ||= Djatoka::Resolver.new(Settings.stacks[driver].url)
   end
 
   def djatoka_path
@@ -62,6 +62,10 @@ class DjatokaImage < SourceImage
                 pth = PathService.for(id, file_name)
                 pth + '.jp2' if pth
               end
+  end
+
+  def driver
+    @driver ||= Settings.stacks.driver
   end
 
   def exceptions_to_retry

--- a/app/models/djatoka_image.rb
+++ b/app/models/djatoka_image.rb
@@ -1,16 +1,17 @@
 # Represents a file on disk, and it's delivery via Djatoka
 class DjatokaImage < SourceImage
   include ActiveSupport::Benchmarkable
-  def initialize(id:, file_name:, transformation:)
+  def initialize(id:, file_name:, transformation:, url:)
     @file = StacksFile.new(id: id, file_name: file_name)
     @transformation = transformation
+    @url = url
   end
 
   # @return [IO]
   def response
-    benchmark "Fetch #{url}" do
+    benchmark "Fetch #{image_url}" do
       # HTTP::Response#body does response streaming
-      HTTP.get(url).body
+      HTTP.get(image_url).body
     end
   end
 
@@ -19,19 +20,19 @@ class DjatokaImage < SourceImage
   end
 
   def valid?
-    url.present?
+    image_url.present?
   end
 
   private
 
-  attr_reader :transformation
+  attr_reader :transformation, :url
   delegate :id, :file_name, :etag, :druid, :mtime, to: :file
   delegate :logger, to: Rails
 
   # @return [StacksFile] the file on disk that back this projection
   attr_reader :file
 
-  def url
+  def image_url
     djatoka_region.url
   rescue Djatoka::IiifInvalidParam
     nil
@@ -50,7 +51,7 @@ class DjatokaImage < SourceImage
   end
 
   def resolver
-    @resolver ||= Djatoka::Resolver.new(Settings.stacks[driver].url)
+    @resolver ||= Djatoka::Resolver.new(@url)
   end
 
   def djatoka_path

--- a/app/models/djatoka_metadata.rb
+++ b/app/models/djatoka_metadata.rb
@@ -48,7 +48,7 @@ class DjatokaMetadata
   def fetch_metadata
     with_retries(max_tries: 3, rescue: exceptions_to_retry) do
       benchmark "Fetching djatoka metadata for #{@stacks_file_path}" do
-        resolver = Djatoka::Resolver.new(Settings.stacks[driver].url)
+        resolver = Djatoka::Resolver.new(Settings.stacks[driver].image.attributes.url)
         resolver.metadata(@stacks_file_path).perform
       end
     end

--- a/app/models/djatoka_metadata.rb
+++ b/app/models/djatoka_metadata.rb
@@ -48,7 +48,7 @@ class DjatokaMetadata
   def fetch_metadata
     with_retries(max_tries: 3, rescue: exceptions_to_retry) do
       benchmark "Fetching djatoka metadata for #{@stacks_file_path}" do
-        resolver = Djatoka::Resolver.new(Settings.stacks.djatoka_url)
+        resolver = Djatoka::Resolver.new(Settings.stacks[driver].url)
         resolver.metadata(@stacks_file_path).perform
       end
     end
@@ -56,6 +56,10 @@ class DjatokaMetadata
 
   def logger
     Rails.logger
+  end
+
+  def driver
+    @driver ||= Settings.stacks.driver
   end
 
   def exceptions_to_retry

--- a/app/services/stacks_image_source_factory.rb
+++ b/app/services/stacks_image_source_factory.rb
@@ -1,12 +1,17 @@
 # Responsible for creating a connection to an image image service
 class StacksImageSourceFactory
   def self.create(id:, file_name:, transformation:)
-    image_source_class.new(id: id, file_name: file_name, transformation: transformation)
+    image_source_class.new(id: id, file_name: file_name, transformation: transformation, url: image_source_url)
   end
 
   def self.image_source_class
-    Settings.stacks[driver].image.constantize
+    Settings.stacks[driver].image.implementation.constantize
   end
+
+  def self.image_source_url
+    Settings.stacks[driver].image.attributes.url
+  end
+
   private_class_method :image_source_class
 
   def self.driver

--- a/app/services/stacks_info_service_factory.rb
+++ b/app/services/stacks_info_service_factory.rb
@@ -5,7 +5,7 @@ class StacksInfoServiceFactory
   end
 
   def self.info_service_class
-    Settings.stacks[driver].info.constantize
+    Settings.stacks[driver].info.implementation.constantize
   end
   private_class_method :info_service_class
 

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -26,6 +26,6 @@ OkComputer::Registry.register 'purl_url', OkComputer::HttpCheck.new(Settings.pur
 #   - in /status/all, these checks will display their result text, but will not affect HTTP response code
 
 # For image content in image viewer
-djatoka_url_to_check = Settings.stacks[Settings.stacks.driver].url + '?rft_id=/&svc_id=info:lanl-repo/svc/ping&url_ver=Z39.88-2004'
+djatoka_url_to_check = Settings.stacks[Settings.stacks.driver].image.attributes.url + '?rft_id=/&svc_id=info:lanl-repo/svc/ping&url_ver=Z39.88-2004'
 OkComputer::Registry.register 'imageserver_url', OkComputer::HttpCheck.new(djatoka_url_to_check)
 OkComputer.make_optional %w(imageserver_url)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -26,6 +26,6 @@ OkComputer::Registry.register 'purl_url', OkComputer::HttpCheck.new(Settings.pur
 #   - in /status/all, these checks will display their result text, but will not affect HTTP response code
 
 # For image content in image viewer
-djatoka_url_to_check = Settings.stacks.djatoka_url + '?rft_id=/&svc_id=info:lanl-repo/svc/ping&url_ver=Z39.88-2004'
+djatoka_url_to_check = Settings.stacks[Settings.stacks.driver].url + '?rft_id=/&svc_id=info:lanl-repo/svc/ping&url_ver=Z39.88-2004'
 OkComputer::Registry.register 'imageserver_url', OkComputer::HttpCheck.new(djatoka_url_to_check)
 OkComputer.make_optional %w(imageserver_url)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,10 +1,10 @@
 stacks:
   storage_root: /stacks
-  djatoka_url: 'http://localhost:8080/resolver'
   driver: djatoka
   djatoka:
     image: DjatokaImage
     info: DjatokaInfoService
+    url: 'http://localhost:8080/resolver'
 
 purl:
   url: 'https://purl.stanford.edu/'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,9 +2,12 @@ stacks:
   storage_root: /stacks
   driver: djatoka
   djatoka:
-    image: DjatokaImage
-    info: DjatokaInfoService
-    url: 'http://localhost:8080/resolver'
+    image:
+      implementation: DjatokaImage
+      attributes:
+        url: 'http://localhost:8080/resolver'
+    info:
+      implementation: DjatokaInfoService
 
 purl:
   url: 'https://purl.stanford.edu/'

--- a/spec/models/djatoka_image_spec.rb
+++ b/spec/models/djatoka_image_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe DjatokaImage do
   subject(:instance) do
     described_class.new(id: id,
                         file_name: 'def',
-                        transformation: nil)
+                        transformation: nil,
+                        url: 'foo')
   end
 
   let(:id) { 'ab012cd3456' }

--- a/spec/requests/iiif_auth_request_spec.rb
+++ b/spec/requests/iiif_auth_request_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:world_unrestricted?).and_return(false)
       allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:url).and_return("url")
+      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
     let!(:si_loc_only) do
@@ -42,7 +42,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:world_rights).and_return([false, ''])
       allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:url).and_return("url")
+      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
     let!(:si_user_not_in_loc) do
@@ -55,7 +55,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:world_rights).and_return([false, ''])
       allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:url).and_return("url")
+      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
     let!(:si_loc_and_stanford) do
@@ -67,7 +67,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:world_rights).and_return([false, ''])
       allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:url).and_return("url")
+      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
     let!(:si_user_not_in_loc_and_stanford) do
@@ -79,7 +79,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:world_rights).and_return([false, ''])
       allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:url).and_return("url")
+      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
 


### PR DESCRIPTION
This moves driver specific settings into attribute values for the image and the info services. The image and info factories will now manage setting the attributes.