### PR TITLE
Give a fully qualified class name

### DIFF
--- a/app/models/iiif/image_request_uri.rb
+++ b/app/models/iiif/image_request_uri.rb
@@ -1,6 +1,6 @@
 module Iiif
   # Class to represent IIIF Image Request URI
-  class ImageRequestUri < URI
+  class ImageRequestUri < Iiif::URI
     # @param base_uri [String]
     # @param identifier [String]
     # @param transformation [Transformation]


### PR DESCRIPTION
Otherwise when the code is eager loaded (production mode) then it
resolves this as ::URI rather than Iiif::URI