### PR TITLE
adds auth service header and service

### DIFF
--- a/app/services/auth_service.rb
+++ b/app/services/auth_service.rb
@@ -18,12 +18,13 @@ class AuthService
       '@context' => 'http://iiif.io/api/auth/1/context.json',
       '@id' => iiif_auth_api_url,
       'profile' => 'http://iiif.io/api/auth/1/login',
-      'label' => 'Log in to access all available features.',
-      'confirmLabel' => 'Login',
+      'label' => 'Stanford users: log in to access all available features.',
+      'header' => 'Stanford-affiliated? Log in to view',
+      'description' => 'Stanford users can click Log in below to access all fea'\
+        'tures.',
+      'confirmLabel' => 'Log in',
       'failureHeader' => 'Unable to authenticate',
-      'failureDescription' => 'The authentication service cannot be reached'\
-        '. If your browser is configured to block pop-up windows, try allow'\
-        'ing pop-up windows for this site before attempting to log in again.',
+      'failureDescription' => 'The authentication service cannot be reached.',
       'service' => [
         {
           '@id' => iiif_token_api_url,

--- a/spec/services/iiif_info_service_spec.rb
+++ b/spec/services/iiif_info_service_spec.rb
@@ -84,13 +84,13 @@ RSpec.describe IiifInfoService do
 
         expect(auth_service['service'].first['profile']).to eq 'http://iiif.io/api/auth/1/token'
         expect(auth_service['service'].first['@id']).to eq 'http://foo/token/api'
-        expect(auth_service['label']).to eq 'Log in to access all available features.'
-        expect(auth_service['confirmLabel']).to eq 'Login'
+        expect(auth_service['label']).to eq 'Stanford users: log in to access all available features.'
+        expect(auth_service['confirmLabel']).to eq 'Log in'
         expect(auth_service['failureHeader']).to eq 'Unable to authenticate'
-        expect(auth_service['failureDescription'])
-          .to eq 'The authentication service cannot be reached. If your brow'\
-          'ser is configured to block pop-up windows, try allowing pop-up wi'\
-          'ndows for this site before attempting to log in again.'
+        expect(auth_service['failureDescription']).to eq 'The authentication service cannot be reached.'
+        expect(auth_service['header']).to eq 'Stanford-affiliated? Log in to view'
+        expect(auth_service['description']).to eq 'Stanford users can click Log'\
+          ' in below to access all features.'
       end
 
       it 'advertises a logout service' do


### PR DESCRIPTION
This PR addresses the empty dialogue issue reported in https://github.com/sul-dlss/sul-embed/issues/821