### PR TITLE
Implement etag on images from iiif

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -16,8 +16,9 @@ class IiifController < ApplicationController
   ##
   # Image delivery, streamed from the image server backend
   def show
-    raise ActionController::MissingFile, 'File Not Found' unless current_image.valid?
     projection = current_image.projection_for(transformation)
+    raise ActionController::MissingFile, 'File Not Found' unless projection.valid?
+
     return unless stale?(cache_headers_show(projection))
     authorize! :read, projection
     expires_in 10.minutes, public: anonymous_ability.can?(:read, projection)

--- a/app/models/djatoka_image.rb
+++ b/app/models/djatoka_image.rb
@@ -1,17 +1,13 @@
-# Represents a file on disk, and it's delivery via Djatoka
+# Represents a file delivered via Djatoka
 class DjatokaImage < SourceImage
   include ActiveSupport::Benchmarkable
   # @param id [StacksIdentifier]
   # @param transformation [Iiif::Transformation]
   # @param url [String] the url for the djatoka resolver
   def initialize(id:, transformation:, url:)
-    @file = StacksFile.new(id: id)
+    @id = id
     @transformation = transformation
     @url = url
-  end
-
-  def exist?
-    file.path.present?
   end
 
   def valid?
@@ -20,12 +16,7 @@ class DjatokaImage < SourceImage
 
   private
 
-  attr_reader :transformation, :url
-  delegate :id, :etag, :mtime, to: :file
-  delegate :logger, to: Rails
-
-  # @return [StacksFile] the file on disk that back this projection
-  attr_reader :file
+  attr_reader :url
 
   def image_url
     djatoka_region.url

--- a/app/models/iiif_image.rb
+++ b/app/models/iiif_image.rb
@@ -5,30 +5,24 @@ class IiifImage < SourceImage
   # @params transformation [Iiif::Transformation]
   # @params base_uri [String]
   def initialize(id:, transformation:, base_uri:)
-    @file = StacksFile.new(id: id)
+    @id = id
     @transformation = transformation
     @base_uri = base_uri
-  end
-
-  def exist?
-    Faraday.head(image_url)
   end
 
   delegate :valid?, to: :image_uri
 
   private
 
-  attr_reader :transformation
-
   def image_uri
-    @image_uri ||= Iiif::URI.new(base_uri: @base_uri, identifier: id, transformation: transformation)
+    @image_uri ||= Iiif::URI.new(base_uri: @base_uri, identifier: remote_id, transformation: transformation)
   end
 
   def image_url
     image_uri.to_s
   end
 
-  def id
-    RemoteIiifIdentifier.convert(@file.id)
+  def remote_id
+    RemoteIiifIdentifier.convert(id)
   end
 end

--- a/app/models/projection.rb
+++ b/app/models/projection.rb
@@ -50,6 +50,10 @@ class Projection
     transformation.region.instance_of? Iiif::Region::Absolute
   end
 
+  def valid?
+    image.exist? && image_source.valid?
+  end
+
   delegate :accessable_by?, :readable_by?, :id, to: :image
   delegate :response, to: :image_source
 

--- a/app/models/source_image.rb
+++ b/app/models/source_image.rb
@@ -10,17 +10,11 @@ class SourceImage
     end
   end
 
-  def exist?; end
-
   def valid?; end
 
-  def etag; end
-
-  def mtime; end
-
-  # I think this is unnecessary in later versions https://github.com/bbatsov/rubocop/pull/3883
-  # rubocop:disable Lint/UselessAccessModifier
   private
+
+  attr_reader :transformation, :id
 
   delegate :logger, to: Rails
 end

--- a/app/models/stacks_image.rb
+++ b/app/models/stacks_image.rb
@@ -32,15 +32,11 @@ class StacksImage
   end
 
   def exist?
-    image_source.exist? && image_width > 0
-  end
-
-  def valid?
-    exist? && image_source.valid?
+    file_source.exist? && image_width > 0
   end
 
   delegate :image_width, :image_height, to: :info_service
-  delegate :etag, :mtime, to: :image_source
+  delegate :etag, :mtime, to: :file_source
 
   # This is overriden in RestrictedImage
   def max_tile_dimensions
@@ -53,14 +49,13 @@ class StacksImage
 
   private
 
+  # @return [StacksFile]
+  def file_source
+    @file_source ||= StacksFile.new(id: id)
+  end
+
   # @return [InfoService]
   def info_service
     @info_service ||= StacksMetadataServiceFactory.create(image_id: id, canonical_url: canonical_url)
-  end
-
-  # @return [SourceImage]
-  def image_source
-    @image_source ||= StacksImageSourceFactory.create(id: id,
-                                                      transformation: transformation)
   end
 end

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe IiifController do
   describe '#show' do
     let(:identifier) { 'nr349ct7889%2Fnr349ct7889_00_0001' }
     let(:image_response) { StringIO.new }
-    let(:projection) { instance_double(Projection, response: image_response) }
+    let(:projection) { instance_double(Projection, response: image_response, valid?: true) }
     let(:image) do
       instance_double(StacksImage,
-                      valid?: true,
                       exist?: true,
                       etag: nil,
                       mtime: nil)
@@ -76,7 +75,7 @@ RSpec.describe IiifController do
     end
 
     it 'missing image returns 404 Not Found' do
-      allow(image).to receive(:valid?).and_return(false)
+      allow(projection).to receive(:valid?).and_return(false)
       expect(subject.status).to eq 404
     end
 

--- a/spec/models/iiif_image_spec.rb
+++ b/spec/models/iiif_image_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe IiifImage do
                         transformation: transformation)
   end
 
-  describe "#id" do
-    subject { instance.send(:id) }
+  describe "#remote_id" do
+    subject { instance.send(:remote_id) }
     it { is_expected.to eq 'st%2F808%2Fxq%2F5141%2Fst808xq5141_00_0001.jp2' }
   end
 

--- a/spec/models/projection_spec.rb
+++ b/spec/models/projection_spec.rb
@@ -191,4 +191,34 @@ RSpec.describe Projection do
       end
     end
   end
+
+  describe '#valid?' do
+    let(:options) { { size: 'max', region: 'full' } }
+    subject { instance.valid? }
+
+    before do
+      allow(StacksImageSourceFactory).to receive(:create).and_return(source_image)
+      allow(StacksFile).to receive(:new).and_return(file)
+    end
+
+    context 'when file exists and transformation is valid' do
+      let(:file) { instance_double(StacksFile, exist?: true) }
+      let(:source_image) { instance_double(SourceImage, valid?: true) }
+      it { is_expected.to be true }
+    end
+
+    context 'when file exists but transformation is not valid' do
+      let(:file) { instance_double(StacksFile, exist?: true) }
+      let(:source_image) { instance_double(SourceImage, valid?: false) }
+
+      it { is_expected.to be false }
+    end
+
+    context 'when file does not exist' do
+      let(:file) { instance_double(StacksFile, exist?: false) }
+      let(:source_image) { instance_double(SourceImage) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/stacks_image_spec.rb
+++ b/spec/models/stacks_image_spec.rb
@@ -68,32 +68,4 @@ RSpec.describe StacksImage do
       expect(subject.canonical_url).to eq attributes[:canonical_url]
     end
   end
-
-  describe '#valid?' do
-    let(:identifier) { StacksIdentifier.new(druid: 'ab012cd3456', file_name: 'def') }
-    let(:instance) { described_class.new(id: identifier, transformation: nil) }
-    subject { instance.valid? }
-
-    before do
-      allow(StacksImageSourceFactory).to receive(:create).and_return(source_image)
-    end
-
-    context 'when source_image exists and is valid' do
-      let(:source_image) { instance_double(SourceImage, valid?: true, exist?: true) }
-
-      it { is_expected.to be true }
-    end
-
-    context 'when source_image exists but is not valid' do
-      let(:source_image) { instance_double(SourceImage, valid?: false, exist?: true) }
-
-      it { is_expected.to be false }
-    end
-
-    context 'when source_image does not exist' do
-      let(:source_image) { instance_double(SourceImage, exist?: false) }
-
-      it { is_expected.to be false }
-    end
-  end
 end

--- a/spec/requests/iiif_auth_request_spec.rb
+++ b/spec/requests/iiif_auth_request_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:world_rights).and_return([false, ''])
       allow(si).to receive(:world_downloadable?).and_return(false)
       allow(si).to receive(:world_unrestricted?).and_return(false)
-      allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
     let!(:si_loc_only) do
@@ -41,9 +39,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:stanford_only_rights).and_return([false, ''])
       allow(si).to receive(:agent_rights).and_return([false, ''])
       allow(si).to receive(:world_rights).and_return([false, ''])
-      allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
     let!(:si_user_not_in_loc) do
@@ -55,9 +51,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:agent_rights).and_return([false, ''])
       allow(si).to receive(:world_downloadable?).and_return(false)
       allow(si).to receive(:world_rights).and_return([false, ''])
-      allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
     let!(:si_loc_and_stanford) do
@@ -67,9 +61,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:restricted_by_location?).and_return(true)
       allow(si).to receive(:agent_rights).and_return([false, ''])
       allow(si).to receive(:world_rights).and_return([false, ''])
-      allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
     let!(:si_user_not_in_loc_and_stanford) do
@@ -81,13 +73,12 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
       allow(si).to receive(:world_downloadable?).and_return(false)
       allow(si).to receive(:stanford_only_downloadable?).and_return(false)
       allow(si).to receive(:world_rights).and_return([false, ''])
-      allow(si).to receive(:valid?).and_return(true)
       allow(si).to receive(:exist?).and_return(true)
-      allow(si.send(:image_source)).to receive(:image_url).and_return("image_url")
       si
     end
 
     before(:each) do
+      allow_any_instance_of(Projection).to receive(:valid?).and_return(true)
       allow(HTTP).to receive(:get).and_return(instance_double(HTTP::Response, body: StringIO.new))
     end
 

--- a/spec/requests/iiif_spec.rb
+++ b/spec/requests/iiif_spec.rb
@@ -10,10 +10,13 @@ RSpec.describe 'IIIF API' do
     instance_double(MetadataService, fetch: metadata,
                                      image_width: 1702)
   end
-  let(:image) do
-    instance_double(StacksImage, exist?: true,
-                                 etag: 'etag',
-                                 mtime: Time.zone.now)
+  let(:stacks_image) do
+    StacksImage.new(id: StacksIdentifier.new(druid: 'nr349ct7889', file_name: 'nr349ct7889_00_0001.jp2'))
+  end
+  let(:file_source) do
+    instance_double(StacksFile, exist?: true,
+                                etag: 'etag',
+                                mtime: Time.zone.now)
   end
 
   before do
@@ -22,8 +25,9 @@ RSpec.describe 'IIIF API' do
     # stubbing Rails.cache.fetch is required because you can't dump a singleton (double)
     # which is what happens when writing to the cache.
     allow(Rails.cache).to receive(:fetch).and_yield
+    allow(StacksImage).to receive(:new).and_return(stacks_image)
+    allow(stacks_image).to receive(:file_source).and_return(file_source)
     allow(StacksMetadataServiceFactory).to receive(:create).and_return(metadata_service)
-    allow(StacksImageSourceFactory).to receive(:create).and_return(image)
   end
 
   it 'redirects base uri requests to the info.json document' do


### PR DESCRIPTION
I think this was overlooked. The easiest way to do this is to just
acknowledge that `/stacks` is mounted.  This has the benefit of reducing
network calls.

Also move the `valid?` check to the Projection.