### PR TITLE
Redirect to URIs when the file extension is missing.

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -4,6 +4,7 @@
 # API for delivering IIIF-compatible images and image tiles
 class IiifController < ApplicationController
   before_action :ensure_valid_identifier
+  before_action :ensure_identifier_has_extension
   before_action :add_iiif_profile_header
 
   # Follow the interface of Riiif
@@ -137,7 +138,7 @@ class IiifController < ApplicationController
   end
 
   def stacks_identifier
-    @stacks_identifier ||= StacksIdentifier.new(escaped_identifier.sub(/^degraded_/, '') + '.jp2')
+    @stacks_identifier ||= StacksIdentifier.new(escaped_identifier.sub(/^degraded_/, ''))
   end
 
   def canonical_params
@@ -166,6 +167,14 @@ class IiifController < ApplicationController
   def degraded?
     !can?(:access, current_image) && current_image.accessable_by?(stanford_generic_user) ||
       !can?(:download, current_image) && current_image.readable_by?(stanford_generic_user)
+  end
+
+  # Stacks used to allow requesting images without an extension. However this was
+  # different than how requests for media or file downloads worked.  Now we prefer the
+  # full file name for consistency across all endpoints.
+  def ensure_identifier_has_extension
+    return if stacks_identifier.has_file_name_extension?
+    redirect_to identifier: stacks_identifier.to_s + '.jp2' # halts the request cycle
   end
 
   def ensure_valid_identifier

--- a/app/models/stacks_identifier.rb
+++ b/app/models/stacks_identifier.rb
@@ -32,6 +32,10 @@ class StacksIdentifier
     File.basename(file_name, '.*')
   end
 
+  def has_file_name_extension?
+    File.extname(file_name).present?
+  end
+
   def treeified_path
     File.join(druid_parts[1..4], file_name)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
 
   constraints identifier: %r{[^/]+}, size: %r{[^/]+} do
     get '/image/iiif/:identifier', to: redirect('/image/iiif/%{identifier}/info.json', status: 303), as: :iiif_base
-    get '/image/iiif/:identifier/:region/:size/:rotation/:quality' => 'iiif#show', as: :iiif
+    get '/image/iiif/:identifier/:region/:size/:rotation/:quality.:format' => 'iiif#show', as: :iiif
     get '/image/iiif/:identifier/info.json' => 'iiif#metadata', as: :iiif_metadata
     match '/image/iiif/:identifier/info.json' => 'iiif#metadata_options', via: [:options]
     get '/image/iiif/app/:identifier/:region/:size/:rotation/:quality' => 'webauth#login_iiif'

--- a/spec/requests/iiif_auth_request_spec.rb
+++ b/spec/requests/iiif_auth_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
   let(:user_webauth_stanford_no_loc) { User.new(webauth_user: true, ldap_groups: %w(stanford:stanford)) }
   let(:user_webauth_stanford_loc) { User.new(webauth_user: true, ldap_groups: %w(stanford:stanford), ip_address: allowed_loc) }
   let(:user_webauth_no_stanford_loc) { User.new(webauth_user: true, ip_address: allowed_loc) }
-  let(:identifier) { StacksIdentifier.new('nr349ct7889%2Fnr349ct7889_00_0001') }
+  let(:identifier) { StacksIdentifier.new('nr349ct7889%2Fnr349ct7889_00_0001.jp2') }
   let(:region) { '0,640,2552,2552' }
   let(:size) { '100,100' }
   let(:rotation) { '0' }
@@ -17,7 +17,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
   let(:format) { 'jpg' }
   let(:params_hash) { { id: identifier, transformation: transformation } }
   let(:transformation) { IIIF::Image::Transformation.new region: region, size: size, rotation: rotation, quality: quality, format: format }
-  let(:path) { "/stacks/nr/349/ct/7889/nr349ct7889_00_0001" }
+  let(:path) { "/stacks/nr/349/ct/7889/nr349ct7889_00_0001.jp2" }
   let(:perms) { nil }
 
   before(:each) do

--- a/spec/requests/iiif_spec.rb
+++ b/spec/requests/iiif_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'IIIF API' do
   end
 
   it 'handles JSON-LD requests' do
-    get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001/info.json', headers: { HTTP_ACCEPT: 'application/ld+json' }
+    get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001.jp2/info.json', headers: { HTTP_ACCEPT: 'application/ld+json' }
 
     expect(response.content_type).to eq 'application/ld+json'
     json = JSON.parse(response.body)
@@ -51,9 +51,9 @@ RSpec.describe 'IIIF API' do
     end
 
     it 'redirects requests to the degraded info.json' do
-      get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001/info.json'
+      get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001.jp2/info.json'
       expect(response).to have_http_status :redirect
-      expect(response).to redirect_to('/image/iiif/degraded_nr349ct7889%252Fnr349ct7889_00_0001/info.json')
+      expect(response).to redirect_to('/image/iiif/degraded_nr349ct7889%252Fnr349ct7889_00_0001.jp2/info.json')
       expect(response.headers['Cache-Control']).to match(/max-age=0/)
     end
 
@@ -71,7 +71,7 @@ RSpec.describe 'IIIF API' do
       stub_rights_xml(world_no_download_xml)
     end
     it 'serves up regular info.json (no degraded)' do
-      get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001/info.json'
+      get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001.jp2/info.json'
       expect(response).to have_http_status :ok
     end
   end
@@ -81,9 +81,9 @@ RSpec.describe 'IIIF API' do
       stub_rights_xml(stanford_only_no_download_xml)
     end
     it 'redirects to degraded version' do
-      get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001/info.json'
+      get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001.jp2/info.json'
       expect(response).to have_http_status :redirect
-      expect(response).to redirect_to('/image/iiif/degraded_nr349ct7889%252Fnr349ct7889_00_0001/info.json')
+      expect(response).to redirect_to('/image/iiif/degraded_nr349ct7889%252Fnr349ct7889_00_0001.jp2/info.json')
     end
   end
 end

--- a/spec/requests/remote_iiif_image_delivery_spec.rb
+++ b/spec/requests/remote_iiif_image_delivery_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "It proxies image requests to a remote IIIF server (canteloupe)" 
   end
 
   it 'returns an image' do
-    get '/image/iiif/nr349ct7889%2Fimage/full/max/0/default.jpg'
+    get '/image/iiif/nr349ct7889%2Fimage.jp2/full/max/0/default.jpg'
     expect(response.body).to eq 'image contents'
   end
 end


### PR DESCRIPTION
Stacks used to allow requesting images without an extension. However
this was different than how requests for media or file downloads worked.
Now we prefer the full file name for consistency across all endpoints.

Fixes #193