### PR TITLE
Avoid using the splat operator

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,7 +42,8 @@ class ApplicationController < ActionController::Base
   end
 
   def bearer_auth_user
-    token_user(*token_and_options(request))
+    token, options = token_and_options(request)
+    token_user(token, options)
   end
 
   def bearer_cookie


### PR DESCRIPTION
The token_user expect 1..2 arguments, but if the token_and_options returns
nil, then we end up sending 0, causing an error.

Fixes #252