### PR TITLE
If an image is restricted by all-or-nothing access (i.e. not degraded…

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -45,9 +45,15 @@ class IiifController < ApplicationController
     expires_in 10.minutes, public: false
     authorize! :read_metadata, current_image
 
+    status = if can? :access, current_image
+               :ok
+             else
+               :unauthorized
+             end
+
     respond_to do |format|
       format.any(:json, :jsonld) do
-        render json: image_info
+        render json: image_info, status: status
       end
     end
   end

--- a/spec/fixtures/rights_xml_fixtures.rb
+++ b/spec/fixtures/rights_xml_fixtures.rb
@@ -54,4 +54,18 @@ module RightsXMLFixtures
       </publicObject>
     XML
   end
+
+  def location_rights_xml
+    <<-XML
+      <publicObject>
+        <rightsMetadata>
+          <access type="read">
+            <machine>
+              <location>location1</location>
+            </machine>
+          </access>
+        </rightsMetadata>
+      </publicObject>
+    XML
+  end
 end

--- a/spec/requests/iiif_spec.rb
+++ b/spec/requests/iiif_spec.rb
@@ -45,6 +45,30 @@ RSpec.describe 'IIIF API' do
     expect(json['tiles']).to eq [{ 'width' => 256, 'height' => 256, 'scaleFactors' => [1, 2, 4, 8, 16] }]
   end
 
+  context 'for location-restricted documents' do
+    before do
+      stub_rights_xml(location_rights_xml)
+    end
+
+    context 'outside of the location' do
+      it 'uses the unauthorized status code for the response' do
+        get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001/info.json'
+        expect(response).to have_http_status :unauthorized
+      end
+    end
+
+    context 'at the location' do
+      let(:user) { User.new(ip_address: 'ip.address1') }
+      before do
+        allow_any_instance_of(IiifController).to receive(:current_user).and_return(user)
+      end
+      it 'uses the ok status code for the response' do
+        get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001/info.json'
+        expect(response).to have_http_status :ok
+      end
+    end
+  end
+
   context 'for stanford-restricted documents' do
     before do
       stub_rights_xml(stanford_restricted_rights_xml)


### PR DESCRIPTION
… to tile-only) and the user doesn't have access, the status of the info.json response should be HTTP Unauthorized.

Per http://iiif.io/api/auth/1.0/#interaction-with-access-controlled-resources.