### PR TITLE
Differentiate 500 vs 503 responses from the image server

### DIFF
--- a/app/services/iiif_metadata_service.rb
+++ b/app/services/iiif_metadata_service.rb
@@ -52,6 +52,8 @@ class IiifMetadataService < MetadataService
     case conn.code
     when 200
       conn.body
+    when 503
+      raise Stacks::ImageServerUnavailable, "Unable to reach image server (503 Service Unavailable) for #{@url}."
     else
       raise Stacks::RetrieveMetadataError, "There was a problem fetching #{@url}. Server returned #{conn.code}"
     end

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -8,4 +8,8 @@ module Stacks
   # RetrieveMetadataError is raised when there is an error retrieving metadata
   # from the image server.
   class RetrieveMetadataError < StandardError; end
+
+  # ImageServerUnavailable is raised when the image server returns
+  # 503 Service Unavailable
+  class ImageServerUnavailable < RetrieveMetadataError; end
 end


### PR DESCRIPTION
When the error is a 503, typically there is a load balancer problem
wheras when it's a 500 typically there is a malformed image that needs
to be corrected.  Splitting this into two different errors will help us
categorize these in Honeybadger.