### PR TITLE
Set the X-Sendfile header for mod_sendfile

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   # config.action_controller.asset_host = 'http://assets.example.com'
 
   # Specifies the header that your server uses for sending files.
-  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   config.action_dispatch.rescue_responses["IIIF::Image::InvalidAttributeError"] = :bad_request


### PR DESCRIPTION
This allows big files to be delivered by Apache rather than using a
Rails server process (which is more resource intensive)

Fixes #334