### PR TITLE
default use of Bearer for authorization token in auth scheme, for III…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,8 @@ class ApplicationController < ActionController::Base
   end
 
   def has_bearer_credentials?(request)
-    request.authorization.present? && (auth_scheme(request) == 'Token')
+    scheme = auth_scheme(request)
+    request.authorization.present? && (scheme == 'Token' || scheme == 'Bearer')
   end
 
   def bearer_cookie_user

--- a/app/controllers/iiif_token_controller.rb
+++ b/app/controllers/iiif_token_controller.rb
@@ -8,7 +8,7 @@ class IiifTokenController < ApplicationController
     @message = if token
                  {
                    accessToken: token,
-                   tokenType: 'Token',
+                   tokenType: 'Bearer',
                    expiresIn: 3600
                  }
                else

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe ApplicationController do
     context 'with a Bearer token' do
       let(:user) { User.new(id: 'test-user', ldap_groups: ['stanford:stanford']) }
       let(:credentials) do
-        ActionController::HttpAuthentication::Token.encode_credentials(user.token)
+        # `encode_credentials` hardcodes `Token` so make sure to test `Bearer`
+        # http://iiif.io/api/auth/1.0/#the-json-access-token-response
+        ActionController::HttpAuthentication::Token.encode_credentials(user.token).gsub('Token', 'Bearer')
       end
 
       before do

--- a/spec/controllers/iiif_token_controller_spec.rb
+++ b/spec/controllers/iiif_token_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe IiifTokenController do
 
           data = JSON.parse(subject.body)
           expect(data['accessToken']).not_to be_blank
-          expect(data['tokenType']).to eq 'Token'
+          expect(data['tokenType']).to eq 'Bearer'
           expect(data['expiresIn']).to be > 0
         end
       end

--- a/spec/features/iiif_spec.rb
+++ b/spec/features/iiif_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'IIIF integration tests' do
 
     # regenerate the token as a token-based user
     allow_any_instance_of(ActionDispatch::Request).to receive(:remote_user).and_return(nil)
-    page.driver.header 'Authorization', "Token #{data['accessToken']}"
+    page.driver.header 'Authorization', "Bearer #{data['accessToken']}"
 
     visit '/image/iiif/token.js'
     data = JSON.parse(page.body)


### PR DESCRIPTION
…F Auth compliance

Fixes https://github.com/sul-dlss/sul-embed/issues/827
Fixes https://github.com/sul-dlss/sul-embed/issues/856

This change fixes a regression introduced in https://github.com/sul-dlss/stacks/pull/221 . The regression switched usage of the authorization header prefix from `Bearer` to `Token`. `Bearer` is required via the [IIIF Auth spec](http://iiif.io/api/auth/1.0/#the-json-access-token-response) and we were not honoring it anymore.

This change should be backwards compatible now accepting both.