### PR TITLE
[WIP] Add the original url as the referrer when redirecting to file and…

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -43,7 +43,7 @@ class FileController < ApplicationController
   def rescue_can_can(exception)
     stanford_restricted, _rule = current_file.stanford_only_rights
     if stanford_restricted && !current_user.webauth_user?
-      redirect_to auth_file_url(allowed_params.to_h.symbolize_keys)
+      redirect_to auth_file_url(allowed_params.to_h.symbolize_keys.merge(referrer: request.original_url))
     else
       super
     end

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -90,7 +90,11 @@ class IiifController < ApplicationController
   #   b)  need user to login to determine if access allowed
   def rescue_can_can(exception)
     if degraded? && !current_user.webauth_user?
-      redirect_to auth_iiif_url(allowed_params.to_h.symbolize_keys.tap { |x| x[:identifier] = escaped_identifier })
+      redirect_to auth_iiif_url(
+        allowed_params.to_h.symbolize_keys.tap do |x|
+          x[:identifier] = escaped_identifier
+        end.merge(referrer: request.original_url)
+      )
     else
       super
     end

--- a/spec/requests/file_auth_request_spec.rb
+++ b/spec/requests/file_auth_request_spec.rb
@@ -104,11 +104,13 @@ RSpec.describe "Authentication for File requests", type: :request do
           expect(response).to have_http_status(403)
         end
       end
-      it "prompts for webauth when user not webauthed" do
+      it "prompts for webauth when user not webauthed (with a referrer param back to the resource)" do
         allow_any_instance_of(FileController).to receive(:current_user).and_return(user_no_loc_no_webauth)
         allow_any_instance_of(FileController).to receive(:current_file).and_return(sf_stanford_only)
         get "/file/#{druid}/#{filename}"
-        expect(response).to redirect_to(auth_file_url(id: druid, file_name: filename))
+        expect(response).to redirect_to(
+          auth_file_url(id: druid, file_name: filename, referrer: file_url(id: druid, file_name: filename))
+        )
       end
     end
     context 'location' do
@@ -164,11 +166,13 @@ RSpec.describe "Authentication for File requests", type: :request do
             expect_any_instance_of(FileController).to receive(:send_file).with(sf_loc_and_stanford.path, disposition: :inline).and_call_original
             get "/file/#{druid}/#{filename}"
           end
-          it 'prompts for webauth when not in location' do
+          it 'prompts for webauth when not in location (with a referrer param back to the resource)' do
             allow_any_instance_of(FileController).to receive(:current_user).and_return(user_no_loc_no_webauth)
             allow_any_instance_of(FileController).to receive(:current_file).and_return(sf_user_not_in_loc_and_stanford)
             get "/file/#{druid}/#{filename}"
-            expect(response).to redirect_to(auth_file_url(id: druid, file_name: filename))
+            expect(response).to redirect_to(
+              auth_file_url(id: druid, file_name: filename, referrer: file_url(id: druid, file_name: filename))
+            )
           end
         end
       end

--- a/spec/requests/iiif_auth_request_spec.rb
+++ b/spec/requests/iiif_auth_request_spec.rb
@@ -106,11 +106,17 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
           expect(response).to have_http_status(403)
         end
       end
-      it "prompts for webauth when user not webauthed" do
+      it "prompts for webauth when user not webauthed (with a referrer param back to the resource)" do
         allow_any_instance_of(IiifController).to receive(:current_user).and_return(user_no_loc_no_webauth)
         allow_any_instance_of(IiifController).to receive(:current_image).and_return(si_stanford_only)
         get "/image/iiif/#{identifier}/#{region}/#{size}/#{rotation}/#{quality}.#{format}"
-        expect(response).to redirect_to(auth_iiif_url(identifier: identifier, format: format))
+        expect(response).to redirect_to(
+          auth_iiif_url(
+            identifier: identifier,
+            format: format,
+            referrer: iiif_url(identifier: identifier, format: format)
+          )
+        )
       end
     end
     context 'location' do
@@ -171,11 +177,17 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
             expect(response).to have_http_status(200)
             expect(response.content_type).to eq('image/jpeg')
           end
-          it 'prompts for webauth when not in location' do
+          it 'prompts for webauth when not in location (with a referrer param back to the resource)' do
             allow_any_instance_of(IiifController).to receive(:current_user).and_return(user_no_loc_no_webauth)
             allow_any_instance_of(IiifController).to receive(:current_image).and_return(si_user_not_in_loc_and_stanford)
             get "/image/iiif/#{identifier}/#{region}/#{size}/#{rotation}/#{quality}.#{format}"
-            expect(response).to redirect_to(auth_iiif_url(identifier: identifier, format: format))
+            expect(response).to redirect_to(
+              auth_iiif_url(
+                identifier: identifier,
+                format: format,
+                referrer: iiif_url(identifier: identifier, format: format)
+              )
+            )
           end
         end
       end


### PR DESCRIPTION
…image auth paths so shib redirects go to the right place

## [WIP] Until we can resolve shibboleth issues

#### Shibboleth appear to have issues in the case that we have here, which is:
* A load balanced application Service Provider
* Does not already have a central session management
* Requires that we control where the user is redirected to after authentication (e.g. back to the protected file they requested).

#### What we've tried so far
* Session stickiness at the load balancer level
  * This caused performance issues w/ the image server
* Using a mysql db as a shared session store at the shibboleth level.
  * This caused redirects back to the root of the application after authentication, regardless of what parameters we were sending.  This appears to be a bug in shibboleth (and/or it's implementation of the session store) AFAICT.

#### Things left to do
* We need to validate if the `/auth` path that we were previously using under WebAuth will suffice.  We currently have both `/auth` and `/file/auth` in @kamchan's puppet branch, so we either need to add the iiif/image paths if needed or fall back to just `/auth` if possible.