### PR TITLE
Store user information in the Rails session

### DIFF
--- a/app/controllers/webauth_controller.rb
+++ b/app/controllers/webauth_controller.rb
@@ -5,6 +5,8 @@ class WebauthController < ApplicationController
     raise CanCan::AccessDenied, 'Unable to authenticate' unless current_user
   end
 
+  before_action :write_auth_session_info, except: [:logout]
+
   def login
     flash[:success] = 'You have been successfully logged in.'
 
@@ -15,6 +17,8 @@ class WebauthController < ApplicationController
   end
 
   def logout
+    session[:remote_user] = nil
+    session[:workgroups] = nil
     respond_to do |format|
       format.html
     end
@@ -29,5 +33,12 @@ class WebauthController < ApplicationController
 
   def login_iiif
     redirect_to iiif_path(params.to_unsafe_h.symbolize_keys)
+  end
+
+  private
+
+  def write_auth_session_info
+    session[:remote_user] = request.env['REMOTE_USER']
+    session[:workgroups] = workgroups_from_env.join(';')
   end
 end

--- a/config/deploy/uat.rb
+++ b/config/deploy/uat.rb
@@ -1,4 +1,5 @@
 server 'sul-stacks-uat.stanford.edu', user: 'stacks', roles: %w{web app}
+server 'sul-stacks-uat-b.stanford.edu', user: 'stacks', roles: %w{web app}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 set :rails_env, 'production'

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe ApplicationController do
       end
     end
 
+    context 'with session information' do
+      before do
+        request.session[:remote_user] = 'my-user'
+        request.session[:workgroups] = 'a;b'
+      end
+
+      it 'retrieves the remote user and workgroup information' do
+        expect(subject.id).to eq 'my-user'
+        expect(subject).to be_a_webauth_user
+        expect(subject.ldap_groups).to match_array %w[a b]
+      end
+    end
+
     context 'with no other credentials' do
       it 'is an anonymous locatable user' do
         expect(subject).to be_an_anonymous_locatable_user

--- a/spec/controllers/webauth_controller_spec.rb
+++ b/spec/controllers/webauth_controller_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe WebauthController do
 
   before do
     allow(controller).to receive(:current_user).and_return(user)
+    request.env['REMOTE_USER'] = 'username'
+    request.env['eduPersonEntitlement'] = 'a;b'
   end
 
   describe '#logout' do
@@ -22,6 +24,11 @@ RSpec.describe WebauthController do
 
     it 'returns the user to the file api' do
       expect(subject).to redirect_to file_url(params)
+    end
+
+    it 'stores user information in the session' do
+      get :login_file, params: params
+      expect(session).to include 'remote_user' => 'username', 'workgroups' => 'a;b'
     end
 
     context 'with a failed login' do
@@ -48,6 +55,11 @@ RSpec.describe WebauthController do
         quality: 'default',
         format: 'jpg'
       }
+    end
+
+    it 'stores user information in the session' do
+      get :login_iiif, params: params
+      expect(session).to include 'remote_user' => 'username', 'workgroups' => 'a;b'
     end
 
     it 'returns the user to the image' do


### PR DESCRIPTION
This allows shibboleth session information to be shared between the application servers.