### PR TITLE
Add quotes around the content disposition file name field

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -123,7 +123,7 @@ class IiifController < ApplicationController
 
   def set_attachment_content_disposition_header
     filename = [stacks_identifier.file_name_without_ext, format_param].join('.')
-    response.headers['Content-Disposition'] = "attachment;filename=#{filename}"
+    response.headers['Content-Disposition'] = "attachment;filename=\"#{filename}\""
   end
 
   def current_image

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe IiifController do
       end
 
       it 'sets the preferred filename' do
-        expect(subject.headers['Content-Disposition']).to include 'filename=nr349ct7889_00_0001.jpg'
+        expect(subject.headers['Content-Disposition']).to include 'filename="nr349ct7889_00_0001.jpg"'
       end
     end
   end


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/sul-embed/issues/1047. I believe this is valid syntax supported by most currenet browsers. There's significant disagreement about what legacy browsers do, but :shrug:
