### PR TITLE
Include an aspect-ratio-respecting size for thumbnail images

### DIFF
--- a/app/models/restricted_image.rb
+++ b/app/models/restricted_image.rb
@@ -8,7 +8,7 @@ class RestrictedImage < StacksImage
   end
 
   def profile
-    ["http://iiif.io/api/image/2/level2", { "maxWidth" => 400 }]
+    ["http://iiif.io/api/image/2/level2", { "maxWidth" => 400, "maxHeight" => 400 }]
   end
 
   # Overides stacks image to provide fixed dimensions

--- a/app/services/iiif_info_service.rb
+++ b/app/services/iiif_info_service.rb
@@ -26,7 +26,7 @@ class IiifInfoService
   def info
     current_image.info.tap do |info|
       info['profile'] = current_image.profile
-      info['sizes'] = [{ width: 400, height: 400 }] unless current_image.maybe_downloadable?
+      info['sizes'] = thumbnail_only_size unless current_image.maybe_downloadable?
 
       service = services unless downloadable_anonymously
       info['service'] = service if service
@@ -42,5 +42,15 @@ class IiifInfoService
     return nil if services.empty?
 
     services.one? ? services.first : services
+  end
+
+  def thumbnail_only_size
+    aspect_ratio = Projection.thumbnail(current_image).region_dimensions.aspect.to_f
+
+    if aspect_ratio > 1
+      [{ width: 400, height: (400 / aspect_ratio).floor }]
+    else
+      [{ width: (400 * aspect_ratio).floor, height: 400 }]
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,11 +6,11 @@ stacks:
       implementation: IiifImage
       attributes:
         # Example: https://sul-imageserver-uat.stanford.edu/cantaloupe/iiif/2/ff%2F139%2Fpd%2F0160%2F67352ccc-d1b0-11e1-89ae-279075081939.jp2/info.json
-        base_uri: https://sul-imageserver-uat.stanford.edu/cantaloupe/iiif/2/
+        base_uri: https://sul-imageserver-uat.stanford.edu/iiif/2/
     metadata:
       implementation: IiifMetadataService
       attributes:
-        base_uri: https://sul-imageserver-uat.stanford.edu/cantaloupe/iiif/2/
+        base_uri: https://sul-imageserver-uat.stanford.edu/iiif/2/
     check:
       implementation: CheckIiif
 

--- a/spec/models/restricted_image_spec.rb
+++ b/spec/models/restricted_image_spec.rb
@@ -23,6 +23,6 @@ RSpec.describe RestrictedImage do
   describe '#profile' do
     subject { instance.profile }
 
-    it { is_expected.to eq ['http://iiif.io/api/image/2/level2', { 'maxWidth' => 400 }] }
+    it { is_expected.to eq ['http://iiif.io/api/image/2/level2', { 'maxHeight' => 400, 'maxWidth' => 400 }] }
   end
 end

--- a/spec/requests/iiif_spec.rb
+++ b/spec/requests/iiif_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe 'IIIF API' do
   end
   let(:metadata_service) do
     instance_double(MetadataService, fetch: metadata,
-                                     image_width: 1702)
+                                     image_width: 1702,
+                                     image_height: 2552)
   end
   let(:stacks_image) do
     StacksImage.new(id: StacksIdentifier.new(druid: 'nr349ct7889', file_name: 'nr349ct7889_00_0001.jp2'))
@@ -113,6 +114,13 @@ RSpec.describe 'IIIF API' do
     it 'serves up regular info.json (no degraded)' do
       get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001/info.json'
       expect(response).to have_http_status :ok
+    end
+
+    it 'replaces the sizes element to reflect the only downloadable (thumbnail) size' do
+      get '/image/iiif/nr349ct7889%2Fnr349ct7889_00_0001/info.json'
+      json = JSON.parse(response.body)
+
+      expect(json['sizes']).to eq [{ 'width' => 266, 'height' => 400 }]
     end
   end
 

--- a/spec/requests/remote_iiif_image_delivery_spec.rb
+++ b/spec/requests/remote_iiif_image_delivery_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe "It proxies image requests to a remote IIIF server (canteloupe)" do
   let(:info_request) do
-    "https://sul-imageserver-uat.stanford.edu/cantaloupe/iiif/2/nr%2F349%2Fct%2F7889%2Fimage.jp2/info.json"
+    "https://sul-imageserver-uat.stanford.edu/iiif/2/nr%2F349%2Fct%2F7889%2Fimage.jp2/info.json"
   end
   let(:info_response) do
     '{
@@ -14,7 +14,7 @@ RSpec.describe "It proxies image requests to a remote IIIF server (canteloupe)" 
   end
 
   let(:image_response) do
-    "https://sul-imageserver-uat.stanford.edu/cantaloupe/iiif/2/nr%2F349%2Fct%2F7889%2Fimage.jp2/full/max/0/default.jpg"
+    "https://sul-imageserver-uat.stanford.edu/iiif/2/nr%2F349%2Fct%2F7889%2Fimage.jp2/full/max/0/default.jpg"
   end
 
   before do


### PR DESCRIPTION
This is related to VUF-7343, but may require additional work in the mirador download plugin to resolve the reported issue.

Fixes https://github.com/sul-dlss/sul-embed/issues/1078.