### PR TITLE
Filter the sizes that are returned from an info.json

### DIFF
--- a/lib/tasks/test_images.rake
+++ b/lib/tasks/test_images.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+desc 'Test image downloads for large pixel size images'
+task test_images: [:environment] do
+  require 'faraday'
+  druids = %w[bf830pb0546 bb023fw1977 fq505jv7833 hs631zg4177 mj244pd1157 st808xq5141 wq035vh2804]
+  conn = Faraday.new ssl: { verify: false }
+  druids.each do |druid|
+    purl_url = "https://sul-purl-uat.stanford.edu/#{druid}/iiif/manifest"
+    resp = conn.get purl_url
+    id = JSON.parse(resp.body)['sequences'][0]['canvases'][0]['images'][0]['resource']['@id']
+    info_json_url = id.gsub('full/full/0/default.jpg', 'info.json')
+    info_resp = conn.get info_json_url
+    sizes = JSON.parse(info_resp.body)['sizes']
+    body_size = 0
+    sizes.each do |size|
+      requested_url = id.gsub('full/full', "full/#{size['width']},")
+      resp = conn.get requested_url
+      status = 'FAIL'
+      if resp.body.length >= body_size
+        body_size = resp.body.length
+        status = 'OK'
+      end
+      puts "#{size['width']}, #{size['height']}, #{status}, #{resp.body.length}, #{requested_url}"
+    end
+  end
+end

--- a/spec/services/iiif_info_service_spec.rb
+++ b/spec/services/iiif_info_service_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe IiifInfoService do
       end
     end
 
+    context 'when the sizes are too large to actually deliver' do
+      let(:source_info) do
+        {
+          'sizes' => [
+            { 'width' => 512, 'height' => 512 },
+            { 'width' => 512_000, 'height' => 512_000 }
+          ]
+        }
+      end
+
+      it 'trims out sizes that are over the maximum servable' do
+        expect(image_info['sizes']).to eq [{ 'width' => 512, 'height' => 512 }]
+      end
+    end
+
     context 'when the tile is exaggerated in dimensions' do
       let(:source_info) do
         { tile_height: 48_915,


### PR DESCRIPTION
Part of https://github.com/sul-dlss/sul-embed/issues/739

Our image server isn't able to correctly process large images. These seem to approach 250,000,000 pixels.

This sets a maximum pixel allowance of 200,000,000 as a general threshold.

Some data about download requests here: https://docs.google.com/spreadsheets/d/1aKeievR9keJVS0TKGq70rPAY7I4CWKT7DpWZsYiLURI/edit#gid=0
