### PR TITLE
Don't treat blank/empty remote users from the request as a…

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
                         bearer_auth_user
                       elsif has_bearer_cookie?
                         bearer_cookie_user
-                      elsif session[:remote_user] || request.remote_user
+                      elsif session[:remote_user] || request.remote_user.present?
                         webauth_user
                       else
                         anonymous_locatable_user

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -63,6 +63,14 @@ RSpec.describe ApplicationController do
       end
     end
 
+    context 'with an empty REMOTE_USER header' do
+      before do
+        request.env['REMOTE_USER'] = ''
+      end
+
+      it { expect(subject).not_to be_a_webauth_user }
+    end
+
     context 'with session information' do
       before do
         request.session[:remote_user] = 'my-user'


### PR DESCRIPTION
…"Webauth" user.

