### PR TITLE
Also skip_forgery_protection on the media api

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -3,6 +3,8 @@
 ##
 # API for delivering streaming media via stacks
 class MediaController < ApplicationController
+  skip_forgery_protection
+
   before_action :load_media
   before_action :set_cors_headers, only: [:auth_check]
 


### PR DESCRIPTION
Part of the Rails 6 update enabled forgery protection by default (which is mostly for the good.. except also includes GET results for our JSON + XML APIs... )