### PR TITLE
URL encode stacks auth tokens for media

### DIFF
--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -48,7 +48,7 @@ class MediaController < ApplicationController
 
   def hash_for_auth_check
     if can? :stream, current_media
-      { status: :success, token: encrypted_token }
+      { status: :success, token: URI.encode_www_form_component(encrypted_token) }
     else
       MediaAuthenticationJson.new(
         user: current_user,


### PR DESCRIPTION
It appears that (possibly due to default cipher changes in rails 6) that tokens now include characters that it didn't before (mainly "+" is what I'm seeing)

The tokens are currently not being encoded, which seems to have been fine, however with these "+" characters we're seeing that when being passed through a URL they're being decoded as a literal space instead of a +

This is causing the token to fail validation because " " != "+"

It seems like ensuring the token is encoded when being sent through the URL will ensure that the auto-decoded parameter we end up w/ in stacks is decoding the correct things.

This is currently deployed to stage (which is updated to Centos7) and uat.