### PR TITLE
Support IIIF authentication  services for controlled digital lending

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ Layout/LineLength:
 Metrics/MethodLength:
   Exclude:
     - 'app/models/ability.rb'
+    - 'app/services/cdl_service.rb'
 
 Naming/HeredocDelimiterNaming:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,8 @@ gem 'dor-rights-auth', require: 'dor/rights_auth'
 gem 'dalli'
 gem 'retries'
 gem 'zipline'
+gem 'jwt'
+gem 'redis'
 
 group :production do
   gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,7 @@ GEM
       activesupport
     jbuilder (2.10.1)
       activesupport (>= 5.0.0)
+    jwt (2.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -261,6 +262,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.2.1)
     regexp_parser (1.8.0)
     retries (0.0.5)
     rexml (3.2.4)
@@ -398,12 +400,14 @@ DEPENDENCIES
   http
   iiif-image-api (~> 0.2)
   jbuilder (~> 2.7)
+  jwt
   listen (>= 3.0.5, < 3.2)
   newrelic_rpm
   okcomputer
   puma (~> 4.3)
   rails (~> 6.0)
   rails-controller-testing
+  redis
   retries
   rspec-rails (~> 4.0)
   rubocop (~> 0.50)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,7 +88,8 @@ class ApplicationController < ActionController::Base
     User.new(id: session[:remote_user] || request.remote_user,
              ip_address: request.remote_ip,
              webauth_user: true,
-             ldap_groups: ldap_groups)
+             ldap_groups: ldap_groups,
+             jwt_tokens: cookies.encrypted[:tokens]).tap { |user| clean_up_expired_cdl_tokens(user) }
   end
 
   def workgroups_from_env
@@ -110,5 +111,11 @@ class ApplicationController < ActionController::Base
     Rails.logger.debug "Access denied on #{exception.action} #{exception.subject.inspect}"
 
     render file: "#{Rails.root}/public/403.html", status: :forbidden, layout: false
+  end
+
+  def clean_up_expired_cdl_tokens(user)
+    return unless cookies.encrypted[:tokens] && user.cdl_tokens.count != cookies.encrypted[:tokens].length
+
+    cookies.encrypted[:tokens] = user.cdl_tokens.pluck(:token)
   end
 end

--- a/app/controllers/cdl_controller.rb
+++ b/app/controllers/cdl_controller.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+##
+# Controlled digital lending endpoint (also protected in production by shibboleth)
+class CdlController < ApplicationController
+  before_action do
+    raise CanCan::AccessDenied, 'Unable to authenticate' unless current_user
+  end
+  skip_forgery_protection only: [:show, :show_options]
+
+  before_action :write_auth_session_info, only: [:create]
+  before_action :validate_token, only: [:delete]
+
+  # Render some information about an active CDL token so the viewer can display e.g.
+  # the current due date.
+  def show
+    render json: {
+      payload: existing_payload&.except(:token),
+      availability_url: ("#{Settings.cdl.url}/availability/#{barcode}" if barcode)
+    }.reject { |_k, v| v.blank? }
+  end
+
+  def show_options
+    response.headers['Access-Control-Allow-Headers'] = 'Authorization'
+    self.response_body = ''
+  end
+
+  # "Check out" a book for controlled digital lending:
+  #   - authenicate the user using shibboleth (so we know they're eligible for CDL)
+  #   - get the Symphony barcode of the digital item
+  #   - bounce the user over to requests to perform the Symphony hold + check out
+  #  THEN, the user gets bounced back to us with a token that represents their successful checkout
+  #    (and coincidentally is also stored + used as the IIIF access cookie)
+  #    The JWT token will contain:
+  #      - jti (circ record key)
+  #      - sub (sunetid)
+  #      - aud (druid)
+  #      - exp (due date)
+  #      - barcode (note: the actual item barcode may differ from the one in the SDR item)
+  def create
+    render json: 'invalid barcode', status: 400 and return unless barcode
+
+    checkout_params = {
+      id: params[:id],
+      barcode: barcode,
+      modal: true,
+      return_to: cdl_checkout_success_iiif_auth_api_url(params[:id])
+    }
+
+    redirect_to "#{Settings.cdl.url}/checkout?#{checkout_params.to_param}"
+  end
+
+  def create_success
+    current_user.append_jwt_token(params[:token])
+    cookies.encrypted[:tokens] = current_user.jwt_tokens
+
+    respond_to do |format|
+      format.html { render html: '<html><script>window.close();</script></html>'.html_safe }
+      format.js { render js: 'window.close();' }
+    end
+  end
+
+  # "Check in" a book from controlled digital lending
+  # As with #create, we bounce the user to requests to handle the Symphony interaction,
+  # and after they come back we'll clean up cookies + tokens on this end.
+  def delete
+    token = existing_payload[:token]
+
+    checkin_params = { token: token, return_to: cdl_checkin_success_iiif_auth_api_url(params[:id]) }
+    redirect_to "#{Settings.cdl.url}/checkin?#{checkin_params.to_param}"
+  end
+
+  def delete_success
+    respond_to do |format|
+      format.html { render html: '<html><script>window.close();</script></html>'.html_safe }
+      format.js { render js: 'window.close();' }
+    end
+  end
+
+  def renew
+    token = existing_payload[:token]
+
+    renew_params = { token: token, return_to: cdl_renew_success_iiif_auth_api_url(params[:id]) }
+    redirect_to "#{Settings.cdl.url}/renew?#{renew_params.to_param}"
+  end
+
+  def renew_success
+    current_user.append_jwt_token(params[:token])
+    cookies.encrypted[:tokens] = current_user.jwt_tokens
+
+    respond_to do |format|
+      format.html { render html: '<html><script>window.close();</script></html>'.html_safe }
+      format.js { render js: 'window.close();' }
+    end
+  end
+
+  private
+
+  def write_auth_session_info
+    return if session[:remote_user]
+
+    session[:remote_user] = request.env['REMOTE_USER']
+    session[:workgroups] = workgroups_from_env.join(';')
+  end
+
+  def existing_payload
+    @existing_payload ||= current_user.cdl_tokens.find { |token| token[:aud] == params[:id] }&.with_indifferent_access
+  end
+
+  def validate_token
+    render json: 'Token not found', status: :bad_request if existing_payload.blank?
+  end
+
+  def barcode
+    @barcode ||= begin
+      return existing_payload&.dig('barcode') if existing_payload&.dig('barcode')
+
+      public_xml = Purl.public_xml(params[:id])
+      doc = Nokogiri::XML.parse(public_xml)
+      barcode = doc.xpath('//identityMetadata/sourceId[@source="sul"]')&.text&.sub(/^stanford_/, '')
+
+      barcode if barcode.starts_with?('36105')
+    end
+  end
+end

--- a/app/controllers/cdl_controller.rb
+++ b/app/controllers/cdl_controller.rb
@@ -84,7 +84,7 @@ class CdlController < ApplicationController
   def renew
     token = existing_payload[:token]
 
-    renew_params = { token: token, return_to: cdl_renew_success_iiif_auth_api_url(params[:id]) }
+    renew_params = { modal: true, token: token, return_to: cdl_renew_success_iiif_auth_api_url(params[:id]) }
     redirect_to "#{Settings.cdl.url}/renew?#{renew_params.to_param}"
   end
 

--- a/app/controllers/cdl_controller.rb
+++ b/app/controllers/cdl_controller.rb
@@ -71,6 +71,10 @@ class CdlController < ApplicationController
   end
 
   def delete_success
+    # Note: the user may have lost its token already (because it was marked as expired)
+    bad_tokens, good_tokens = current_user.cdl_tokens.partition { |payload| payload['aud'] == params[:id] }
+    cookies.encrypted[:tokens] = good_tokens.pluck(:token) if bad_tokens.any?
+
     respond_to do |format|
       format.html { render html: '<html><script>window.close();</script></html>'.html_safe }
       format.js { render js: 'window.close();' }

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -25,7 +25,7 @@ class IiifController < ApplicationController
     return unless stale?(cache_headers_show(projection))
 
     authorize! :read, projection
-    expires_in 10.minutes, public: anonymous_ability.can?(:read, projection)
+    expires_in cache_time, public: anonymous_ability.can?(:read, projection)
 
     set_image_response_headers
 
@@ -46,7 +46,7 @@ class IiifController < ApplicationController
       return
     end
 
-    expires_in 10.minutes, public: false
+    expires_in cache_time, public: false
     authorize! :read_metadata, current_image
 
     status = if degraded_identifier? || can?(:access, current_image)
@@ -189,5 +189,11 @@ class IiifController < ApplicationController
 
   def ensure_valid_identifier
     raise ActionController::RoutingError, "invalid identifer" unless stacks_identifier.valid?
+  end
+
+  def cache_time
+    return 1.minute if current_image.cdl_restricted?
+
+    10.minutes
   end
 end

--- a/app/controllers/iiif_token_controller.rb
+++ b/app/controllers/iiif_token_controller.rb
@@ -32,7 +32,11 @@ class IiifTokenController < ApplicationController
   # app-user, or are accessing material from a location-specific kiosk.
   # Other anonymous users are not eligible.
   def token_eligible_user?
-    current_user.token_user? || current_user.webauth_user? || current_user.app_user? || current_user.location?
+    current_user.token_user? ||
+      current_user.webauth_user? ||
+      current_user.app_user? ||
+      current_user.location? ||
+      current_user.cdl_tokens.any?
   end
 
   # Handle IIIF Authentication 1.0 browser-based client application requests

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -99,6 +99,20 @@ class Ability
       end
     end
 
+    if user.cdl_tokens.present?
+      # TODO: Actually check if the CDL object is downloadable
+      # can [:download, :read], models do |f|
+      #   ...
+      # end
+
+      can [:access], models do |f|
+        value, _rule = f.rights.cdl_rights_for_file(f.id.file_name)
+        next unless value
+
+        user.cdl_tokens.any? { |payload| payload['aud'] == f.id.druid }
+      end
+    end
+
     cannot :download, RestrictedImage
 
     # These are called when checking to see if the image response should be served

--- a/app/models/concerns/stacks_rights.rb
+++ b/app/models/concerns/stacks_rights.rb
@@ -14,6 +14,12 @@ module StacksRights
     value
   end
 
+  def cdl_restricted?
+    value, _rule = rights.cdl_rights_for_file id.file_name
+
+    value
+  end
+
   # Returns true if a given file has any location restrictions.
   #   Falls back to the object-level behavior if none at file level.
   def restricted_by_location?

--- a/app/services/cdl_service.rb
+++ b/app/services/cdl_service.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Produces iiif services for checking items out using CDL
+class CdlService
+  # helper method to create a new auth service
+  # @param context [IiifController] a controller context used to make url helpers
+  def self.to_iiif(context, current_image)
+    new(context, current_image).to_iiif
+  end
+
+  # @param context [IiifController] a controller context used to make url helpers
+  def initialize(context, current_image)
+    @context = context
+    @current_image = current_image
+  end
+
+  def to_iiif
+    {
+      '@context' => 'http://iiif.io/api/auth/1/context.json',
+      '@id' => cdl_checkout_iiif_auth_api_url(id),
+      'profile' => 'http://iiif.io/api/auth/1/login',
+      'label' => 'Available for checkout',
+      'header' => 'SUNetID required: This item is available to Stanford affiliates only. Download is prohibited.',
+      'confirmLabel' => 'Check out',
+      'failureHeader' => 'Unable to authenticate',
+      'failureDescription' => 'The authentication service cannot be reached.',
+      'service' => [
+        {
+          '@id' => cdl_iiif_token_api_url(id),
+          'profile' => 'http://iiif.io/api/auth/1/token'
+        },
+        {
+          '@id' => cdl_checkin_iiif_auth_api_url(id),
+          'profile' => 'http://iiif.io/api/auth/1/logout',
+          'label' => 'Check in early'
+        },
+        {
+          '@id' => cdl_info_iiif_auth_api_url(id),
+          'profile' => 'http://iiif.io/api/auth/1/info'
+        },
+        {
+          '@id' => cdl_renew_iiif_auth_api_url(id),
+          'profile' => 'http://iiif.io/api/auth/1/renew'
+        }
+      ]
+    }
+  end
+
+  delegate :cdl_checkout_iiif_auth_api_url, :cdl_checkin_iiif_auth_api_url,
+           :cdl_iiif_token_api_url, :cdl_info_iiif_auth_api_url, :cdl_renew_iiif_auth_api_url, to: :url_helpers
+
+  def url_helpers
+    @context
+  end
+
+  def id
+    @current_image.id.druid
+  end
+end

--- a/app/services/iiif_info_service.rb
+++ b/app/services/iiif_info_service.rb
@@ -69,6 +69,7 @@ class IiifInfoService
     services = []
     services << AuthService.to_iiif(context) if current_image.stanford_restricted?
     services << LocationService.to_iiif(context) if current_image.restricted_by_location?
+    services << CdlService.to_iiif(context, current_image) if current_image.cdl_restricted?
     return nil if services.empty?
 
     services.one? ? services.first : services

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -19,6 +19,8 @@ OkComputer::Registry.register 'stacks_mounted_dir',
 
 OkComputer::Registry.register 'purl_url', OkComputer::HttpCheck.new(Settings.purl.url + "status/default.json")
 
+OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(Settings.cdl.redis.to_h) if Settings.cdl.redis
+OkComputer.make_optional %w(redis)
 # ------------------------------------------------------------------------------
 
 # NON-CRUCIAL (Optional) checks, avail at /status/<name-of-check>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,8 +19,17 @@ Rails.application.routes.draw do
   root 'stacks#index'
 
   get '/auth/iiif' => 'webauth#login', as: :iiif_auth_api
+  get '/auth/iiif/cdl/:id/checkout' => 'cdl#create', as: :cdl_checkout_iiif_auth_api
+  get '/auth/iiif/cdl/:id/checkin' => 'cdl#delete', as: :cdl_checkin_iiif_auth_api
+  get '/auth/iiif/cdl/:id/renew' => 'cdl#renew', as: :cdl_renew_iiif_auth_api
+  get '/auth/iiif/cdl/:id/checkout/success' => 'cdl#create_success', as: :cdl_checkout_success_iiif_auth_api
+  get '/auth/iiif/cdl/:id/checkin/success' => 'cdl#delete_success', as: :cdl_checkin_success_iiif_auth_api
+  get '/auth/iiif/cdl/:id/renew/success' => 'cdl#renew_success', as: :cdl_renew_success_iiif_auth_api
+  get '/cdl/:id' => 'cdl#show', as: :cdl_info_iiif_auth_api
+  match '/cdl/:id' => 'cdl#show_options', via: [:options]
   get '/auth/logout' => 'webauth#logout', as: :logout
   get '/image/iiif/token' => 'iiif_token#create', as: :iiif_token_api
+  get '/image/iiif/token/:id' => 'iiif_token#create', as: :cdl_iiif_token_api
 
   constraints identifier: %r{[^/]+}, size: %r{[^/]+} do
     get '/image/iiif/:identifier', to: redirect('/image/iiif/%{identifier}/info.json', status: 303), as: :iiif_base

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,7 @@ purl:
   url: 'https://purl.stanford.edu/'
 
 cdl:
+  url: 'https://requests.stanford.edu/cdl'
   jwt:
     algorithm: 'HS256'
     secret: secret

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,6 +18,12 @@ stacks:
 purl:
   url: 'https://purl.stanford.edu/'
 
+cdl:
+  jwt:
+    algorithm: 'HS256'
+    secret: secret
+  redis: {}
+
 stream:
   # max_token_age is specified in seconds
   max_token_age: 45

--- a/spec/controllers/cdl_controller_spec.rb
+++ b/spec/controllers/cdl_controller_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CdlController do
+  let(:user) { User.new id: 'username', jwt_tokens: [token] }
+  let(:token) { JWT.encode(payload, Settings.cdl.jwt.secret, Settings.cdl.jwt.algorithm) }
+  let(:payload) { { aud: 'druid', sub: 'username', exp: (Time.zone.now + 1.day).to_i, barcode: '36105110268922' } }
+
+  let(:barcoded_item_xml) do
+    <<-EOXML
+      <publicObject>
+        <identityMetadata>
+          <sourceId source="sul">36105110268922</sourceId>
+        </identityMetadata>
+      </publicObject>
+    EOXML
+  end
+
+  let(:non_barcoded_item_xml) do
+    <<-EOXML
+      <publicObject>
+        <identityMetadata>
+          <sourceId source="sul">this is not a barcode</sourceId>
+        </identityMetadata>
+      </publicObject>
+    EOXML
+  end
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    cookies.encrypted[:tokens] = [token]
+  end
+
+  describe '#show' do
+    context 'without a token' do
+      before do
+        allow(Purl).to receive(:public_xml).with('other-druid').and_return(barcoded_item_xml)
+      end
+
+      it 'includes a url to look up availability' do
+        get :show, { params: { id: 'other-druid' } }
+
+        expect(response.status).to eq 200
+        expect(JSON.parse(response.body).with_indifferent_access).to include(
+          availability_url: match(%(cdl/availability/36105110268922))
+        )
+      end
+    end
+
+    it 'renders some information from the token' do
+      get :show, { params: { id: 'druid' } }
+
+      expect(response.status).to eq 200
+      expect(JSON.parse(response.body).with_indifferent_access).to include(
+        payload: hash_including(sub: 'username', aud: 'druid', exp: a_kind_of(Numeric))
+      )
+    end
+
+    it 'includes a url to look up availability' do
+      get :show, { params: { id: 'druid' } }
+
+      expect(JSON.parse(response.body).with_indifferent_access).to include(
+        availability_url: match(%(cdl/availability/36105110268922))
+      )
+    end
+  end
+
+  describe '#create' do
+    context 'with a token' do
+      let(:new_token) do
+        JWT.encode(payload.merge(aud: 'other-druid'), Settings.cdl.jwt.secret, Settings.cdl.jwt.algorithm)
+      end
+
+      it 'stores the token in a cookie' do
+        get :create_success, { params: { id: 'other-druid', token: new_token } }
+
+        expect(cookies.encrypted[:tokens].length).to eq 2
+      end
+    end
+
+    context 'with an updated token' do
+      let(:new_exp) { 2.days.from_now.to_i }
+      let(:new_token) do
+        JWT.encode(
+          payload.merge(iat: Time.zone.now.to_i, exp: new_exp),
+          Settings.cdl.jwt.secret,
+          Settings.cdl.jwt.algorithm
+        )
+      end
+
+      it 'stores the token in a cookie' do
+        get :create_success, { params: { id: 'druid', token: new_token } }
+
+        expect(cookies.encrypted[:tokens].length).to eq 1
+        expect(controller.send(:current_user).cdl_tokens.first[:exp]).to eq new_exp
+      end
+    end
+
+    it 'bounces you to requests to handle the symphony interaction' do
+      allow(Purl).to receive(:public_xml).with('other-druid').and_return(barcoded_item_xml)
+
+      get :create, { params: { id: 'other-druid' } }
+
+      expect(response).to redirect_to('https://requests.stanford.edu/cdl/checkout?barcode=36105110268922&id=other-druid&modal=true&return_to=http%3A%2F%2Ftest.host%2Fauth%2Fiiif%2Fcdl%2Fother-druid%2Fcheckout%2Fsuccess')
+    end
+
+    context 'with a record without a barcode' do
+      it 'is a 400' do
+        allow(Purl).to receive(:public_xml).with('other-druid').and_return(non_barcoded_item_xml)
+        get :create, { params: { id: 'other-druid' } }
+
+        expect(response.status).to eq 400
+      end
+    end
+  end
+
+  describe '#delete' do
+    it 'bounces you to requests to handle the symphony interaction' do
+      get :delete, params: { id: 'druid' }
+
+      url = 'http%3A%2F%2Ftest.host%2Fauth%2Fiiif%2Fcdl%2Fdruid%2Fcheckin%2Fsuccess'
+      expect(response).to redirect_to("https://requests.stanford.edu/cdl/checkin?return_to=#{url}&token=#{token}")
+    end
+  end
+end

--- a/spec/controllers/file_controller_spec.rb
+++ b/spec/controllers/file_controller_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe FileController do
     subject { get :show, params: { id: druid, file_name: 'xf680rd3068_1.jp2' } }
 
     before do
-      allow(file).to receive_messages(mtime: Time.zone.now, path: File.join(Rails.root, 'Gemfile'))
+      path = File.join(Rails.root, 'spec/fixtures/nr/349/ct/7889/image.jp2')
+      allow(file).to receive_messages(mtime: Time.zone.now, path: path)
     end
 
     context "with an invalid druid" do
@@ -34,7 +35,7 @@ RSpec.describe FileController do
     it 'sends headers for content' do
       expect(controller).to receive(:send_file).with(file.path, disposition: :attachment).and_call_original
       get :show, params: { id: 'xf680rd3068', file_name: 'xf680rd3068_1.jp2', download: 'any' }
-      expect(response.headers.to_h).to include 'Content-Length' => 2434, 'Accept-Ranges' => 'bytes'
+      expect(response.headers.to_h).to include 'Content-Length' => 11_043, 'Accept-Ranges' => 'bytes'
     end
 
     it 'sets disposition attachment with download param' do

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -3,16 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe IiifController do
+  let(:image) do
+    instance_double(StacksImage,
+                    valid?: true,
+                    exist?: true,
+                    etag: nil,
+                    mtime: nil,
+                    cdl_restricted?: false)
+  end
+
   describe '#show' do
     let(:identifier) { 'nr349ct7889%2Fnr349ct7889_00_0001' }
     let(:image_response) { instance_double(HTTP::Response, body: StringIO.new, status: 200) }
     let(:projection) { instance_double(Projection, response: image_response, valid?: true) }
-    let(:image) do
-      instance_double(StacksImage,
-                      exist?: true,
-                      etag: nil,
-                      mtime: nil)
-    end
     let(:transformation) { double }
 
     let(:iiif_params) do
@@ -100,13 +103,6 @@ RSpec.describe IiifController do
   end
 
   describe '#metadata' do
-    let(:image) do
-      instance_double(StacksImage,
-                      valid?: true,
-                      exist?: true,
-                      etag: nil,
-                      mtime: nil)
-    end
     let(:anon_user) { instance_double(User, stanford?: false, app_user?: false, locations: [], cdl_tokens: []) }
 
     before do

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe IiifController do
                       etag: nil,
                       mtime: nil)
     end
-    let(:anon_user) { instance_double(User, stanford?: false, app_user?: false, locations: []) }
+    let(:anon_user) { instance_double(User, stanford?: false, app_user?: false, locations: [], cdl_tokens: []) }
 
     before do
       # for the cache headers

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -34,4 +34,65 @@ RSpec.describe User do
       expect(User.new(ip_address: 'ip.address1').locations).to eq %w[location1 location2]
     end
   end
+
+  context 'with JWT tokens' do
+    subject(:user) do
+      User.new(
+        id: 'xyz',
+        jwt_tokens: jwt_tokens.map do |payload|
+          JWT.encode(payload, Settings.cdl.jwt.secret, Settings.cdl.jwt.algorithm)
+        end
+      )
+    end
+
+    let(:jwt_tokens) do
+      [
+        { jti: 'a', sub: 'xyz', exp: (Time.zone.now + 1.hour).to_i }
+      ]
+    end
+
+    describe '#cdl_tokens' do
+      it 'decodes the JWT token' do
+        payload = user.cdl_tokens.first
+
+        expect(payload).to include jti: 'a', sub: 'xyz'
+      end
+
+      it 'embeds the original token in the payload' do
+        payload = user.cdl_tokens.first
+
+        expect(payload).to include token: user.jwt_tokens.first
+      end
+
+      context 'with an expired token' do
+        let(:jwt_tokens) do
+          [
+            { jti: 'a', sub: 'xyz', exp: (Time.zone.now - 1.hour).to_i }
+          ]
+        end
+
+        it 'filters expired tokens' do
+          expect(user.cdl_tokens.count).to eq 0
+        end
+      end
+
+      context 'with a token for another user' do
+        let(:jwt_tokens) do
+          [
+            { jti: 'a', sub: 'abc', exp: (Time.zone.now + 1.hour).to_i }
+          ]
+        end
+
+        it 'filters tokens for other users' do
+          expect(user.cdl_tokens.count).to eq 0
+        end
+      end
+    end
+
+    it 'round-trips the JWT tokens through IIIF access tokens' do
+      tokenized_user = User.from_token(user.token)
+
+      expect(tokenized_user.jwt_tokens).to eq user.jwt_tokens
+    end
+  end
 end

--- a/spec/routing/cdl_routing_spec.rb
+++ b/spec/routing/cdl_routing_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'CDL routes', type: :routing do
+  it 'routes to #show' do
+    expect(get: '/cdl/druid').to route_to('cdl#show', id: 'druid')
+  end
+
+  it 'routes to #create' do
+    expect(get: '/auth/iiif/cdl/druid/checkout').to route_to('cdl#create', id: 'druid')
+  end
+
+  it 'routes to #delete' do
+    expect(get: '/auth/iiif/cdl/druid/checkin').to route_to('cdl#delete', id: 'druid')
+  end
+end

--- a/spec/services/iiif_info_service_spec.rb
+++ b/spec/services/iiif_info_service_spec.rb
@@ -115,6 +115,7 @@ RSpec.describe IiifInfoService do
 
       before do
         allow(image).to receive(:stanford_restricted?).and_return(true)
+        allow(image).to receive(:cdl_restricted?).and_return(false)
       end
 
       it 'the tile height/width is 256' do

--- a/spec/services/media_authentication_json_spec.rb
+++ b/spec/services/media_authentication_json_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe MediaAuthenticationJson do
     )
   end
   let(:ability) { Ability.new(user) }
-  let(:user) { double('User', locations: [], webauth_user: false, stanford?: false, app_user?: false) }
+  let(:user) { double('User', locations: [], webauth_user: false, stanford?: false, app_user?: false, cdl_tokens: []) }
   subject { described_class.new(media: media, user: user, auth_url: '/the/auth/url', ability: ability) }
 
   describe 'Location Restricted Media' do


### PR DESCRIPTION
This PR adds support for controlled digital lending  using the IIIF Auth  API. Items are "checked out" using the IIIF login auth pattern, forwards the user to sul-requests to perform the Symphony interactions, and returns to stacks with a JWT token that "authorizes" the viewer.

The basic version should work with any IIIF-capable viewer, but additional functionality will need to come from a custom viewer plugin.

