### PR TITLE
Remove url normalization from our HTTP calls to the imageserver

### DIFF
--- a/app/models/source_image.rb
+++ b/app/models/source_image.rb
@@ -9,7 +9,9 @@ class SourceImage
   def response
     with_retries max_tries: 3, rescue: [HTTP::ConnectionError] do
       benchmark "Fetch #{image_url}" do
-        HTTP.get(image_url)
+        # Disable url normalization as an upstream bug in addressable causes issues for `+`
+        # https://github.com/sporkmonger/addressable/issues/386
+        HTTP.use({ normalize_uri: { normalizer: lambda(&:itself) } }).get(image_url)
       end
     end
   end

--- a/app/services/iiif_metadata_service.rb
+++ b/app/services/iiif_metadata_service.rb
@@ -44,7 +44,11 @@ class IiifMetadataService < MetadataService
   # @return [String] the IIIF info response
   def retrieve
     with_retries max_tries: 3, rescue: [HTTP::ConnectionError] do
-      handle_response(HTTP.get(@url))
+      handle_response(
+        # Disable url normalization as an upstream bug in addressable causes issues for `+`
+        # https://github.com/sporkmonger/addressable/issues/386
+        HTTP.use({ normalize_uri: { normalizer: lambda(&:itself) } }).get(@url)
+      )
     end
   end
 

--- a/spec/models/projection_spec.rb
+++ b/spec/models/projection_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Projection do
   let(:image) { StacksImage.new }
   let(:instance) { described_class.new(image, transformation) }
   let(:transformation) { IIIF::Image::OptionDecoder.decode(options) }
+  let(:http_client) { instance_double(HTTP::Client) }
 
   before do
     allow(image).to receive_messages(image_width: 800, image_height: 600)
@@ -105,9 +106,11 @@ RSpec.describe Projection do
         let(:options) { { size: 'max', region: 'full' } }
 
         it 'allows the user to see the full-resolution image' do
-          allow(HTTP).to receive(:get).and_return(double(body: nil))
+          allow(HTTP).to receive(:use)
+            .and_return(http_client)
+          allow(http_client).to receive(:get).and_return(double(body: nil))
           subject.response
-          expect(HTTP).to have_received(:get).with(%r{/full/max/0/default.jpg})
+          expect(http_client).to have_received(:get).with(%r{/full/max/0/default.jpg})
         end
       end
     end
@@ -121,9 +124,11 @@ RSpec.describe Projection do
         let(:options) { { size: 'max', region: 'full' } }
 
         it 'limits users to a thumbnail' do
-          allow(HTTP).to receive(:get).and_return(double(body: nil))
+          allow(HTTP).to receive(:use)
+            .and_return(http_client)
+          allow(http_client).to receive(:get).and_return(double(body: nil))
           subject.response
-          expect(HTTP).to have_received(:get).with(%r{/full/!400,400/0/default.jpg})
+          expect(http_client).to have_received(:get).with(%r{/full/!400,400/0/default.jpg})
         end
       end
 
@@ -131,9 +136,11 @@ RSpec.describe Projection do
         let(:options) { { size: '!100,100', region: 'full' } }
 
         it 'limits users to a thumbnail' do
-          allow(HTTP).to receive(:get).and_return(double(body: nil))
+          allow(HTTP).to receive(:use)
+            .and_return(http_client)
+          allow(http_client).to receive(:get).and_return(double(body: nil))
           subject.response
-          expect(HTTP).to have_received(:get).with(%r{/full/!100,100/0/default.jpg})
+          expect(http_client).to have_received(:get).with(%r{/full/!100,100/0/default.jpg})
         end
       end
 
@@ -141,9 +148,11 @@ RSpec.describe Projection do
         let(:options) { { size: '!800,880', region: 'full' } }
 
         it 'limits users to a thumbnail' do
-          allow(HTTP).to receive(:get).and_return(double(body: nil))
+          allow(HTTP).to receive(:use)
+            .and_return(http_client)
+          allow(http_client).to receive(:get).and_return(double(body: nil))
           subject.response
-          expect(HTTP).to have_received(:get).with(%r{/full/!400,400/0/default.jpg})
+          expect(http_client).to have_received(:get).with(%r{/full/!400,400/0/default.jpg})
         end
       end
 
@@ -151,9 +160,11 @@ RSpec.describe Projection do
         let(:options) { { size: '100,100', region: 'square' } }
 
         it 'limits users to a thumbnail' do
-          allow(HTTP).to receive(:get).and_return(double(body: nil))
+          allow(HTTP).to receive(:use)
+            .and_return(http_client)
+          allow(http_client).to receive(:get).and_return(double(body: nil))
           subject.response
-          expect(HTTP).to have_received(:get).with(%r{/square/100,100/0/default.jpg})
+          expect(http_client).to have_received(:get).with(%r{/square/100,100/0/default.jpg})
         end
       end
     end

--- a/spec/requests/iiif_auth_request_spec.rb
+++ b/spec/requests/iiif_auth_request_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
   let(:path) { "/stacks/nr/349/ct/7889/nr349ct7889_00_0001" }
   let(:perms) { nil }
   let(:current_image) { StacksImage.new(params_hash) }
+  let(:http_client) { instance_double(HTTP::Client) }
 
   before(:each) do
     allow(File).to receive(:world_readable?).with(path).and_return(perms)
@@ -30,7 +31,9 @@ RSpec.describe "Authentication for IIIF requests", type: :request do
   describe "#show" do
     before(:each) do
       allow_any_instance_of(Projection).to receive(:valid?).and_return(true)
-      allow(HTTP).to receive(:get).and_return(instance_double(HTTP::Response, status: 200, body: StringIO.new))
+      allow(HTTP).to receive(:use)
+        .and_return(http_client)
+      allow(http_client).to receive(:get).and_return(instance_double(HTTP::Response, status: 200, body: StringIO.new))
 
       allow_any_instance_of(IiifController).to receive(:current_user).and_return(current_user)
       allow_any_instance_of(IiifController).to receive(:current_image).and_return(current_image)

--- a/spec/services/iiif_metadata_service_spec.rb
+++ b/spec/services/iiif_metadata_service_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe IiifMetadataService do
   end
   let(:base_uri) { 'https://sul-imageserver-uat.stanford.edu/cantaloupe/iiif/2/' } # 'image-server-path'
   let(:service) { described_class.new(image_id: identifier, canonical_url: 'foo', base_uri: base_uri) }
+  let(:http_client) { instance_double(HTTP::Client) }
 
   context "When a valid JSON response is received" do
     let(:json) do
@@ -19,8 +20,11 @@ RSpec.describe IiifMetadataService do
       '"sizes":[{"width":1916,"height":1276}]}'
     end
     let(:response) { instance_double(HTTP::Response, code: 200, body: json) }
+
     before do
-      allow(HTTP).to receive(:get)
+      allow(HTTP).to receive(:use)
+        .and_return(http_client)
+      allow(http_client).to receive(:get)
         .with('https://sul-imageserver-uat.stanford.edu/cantaloupe/iiif/2/nr%2F349%2Fct%2F7889%2Fnr349ct7889_00_0001.jp2/info.json')
         .and_return(response)
     end
@@ -54,7 +58,9 @@ RSpec.describe IiifMetadataService do
     let(:empty_json) { '' }
     let(:bad_response) { instance_double(HTTP::Response, code: 200, body: empty_json) }
     before do
-      allow(HTTP).to receive(:get)
+      allow(HTTP).to receive(:use)
+        .and_return(http_client)
+      allow(http_client).to receive(:get)
         .with('https://sul-imageserver-uat.stanford.edu/cantaloupe/iiif/2/nr%2F349%2Fct%2F7889%2Fnr349ct7889_00_0001.jp2/info.json')
         .and_return(bad_response)
     end


### PR DESCRIPTION
We are removing the default HTTP gem URL normalization because there is
an upstream error which causes issues for `+` characters.

https://github.com/sporkmonger/addressable/issues/386