### PR TITLE
Configure protect_from_forgery to allow api requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,8 @@ class ApplicationController < ActionController::Base
   end
   before_action :set_origin_header
 
+  protect_from_forgery with: :null_session
+
   private
 
   def set_origin_header


### PR DESCRIPTION
From https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html

> APIs may want to disable this behavior since they are typically designed to be state-less: that is, the request API client handles the session instead of Rails. One way to achieve this is to use the :null_session strategy instead, which allows unverified requests to be handled, but with an empty session.
