### PR TITLE
Send keyword parameters instead of a hash to fix some deprecation warnings

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -8,7 +8,7 @@ class FileController < ApplicationController
   end
 
   def show
-    return unless stale?(cache_headers)
+    return unless stale?(**cache_headers)
 
     authorize! :read, current_file
     expires_in 10.minutes

--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -17,7 +17,7 @@ class IiifController < ApplicationController
     projection = current_image.projection_for(transformation)
     raise ActionController::MissingFile, 'File Not Found' unless projection.valid?
 
-    return unless stale?(cache_headers_show(projection))
+    return unless stale?(**cache_headers_show(projection))
 
     authorize! :read, projection
     expires_in cache_time, public: anonymous_ability.can?(:read, projection)
@@ -34,7 +34,7 @@ class IiifController < ApplicationController
   def metadata
     raise ActionController::MissingFile, 'File Not Found' unless current_image.exist?
 
-    return unless stale?(cache_headers_metadata)
+    return unless stale?(**cache_headers_metadata)
 
     if !degraded? && degradable?
       redirect_to degraded_iiif_metadata_url(id: identifier_params[:id], file_name: identifier_params[:file_name])


### PR DESCRIPTION
```
App 20356 output: /opt/app/stacks/stacks/shared/bundle/ruby/2.7.0/gems/actionpack-6.1.4.4/lib/action_controller/metal/conditional_get.rb:219: warning: The called method `stale?' is defined here
App 20376 output: /opt/app/stacks/stacks/releases/20220110172201/app/controllers/iiif_controller.rb:20: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
App 20376 output: /opt/app/stacks/stacks/shared/bundle/ruby/2.7.0/gems/actionpack-6.1.4.4/lib/action_controller/metal/conditional_get.rb:219: warning: The called method `stale?' is defined here
App 20314 output: /opt/app/stacks/stacks/releases/20220110172201/app/controllers/iiif_controller.rb:37: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```