### PR TITLE
Use the full URL for level 2 image API compliance

### DIFF
--- a/app/models/restricted_image.rb
+++ b/app/models/restricted_image.rb
@@ -8,7 +8,7 @@ class RestrictedImage < StacksImage
   end
 
   def profile
-    ["http://iiif.io/api/image/2/level2", { "maxWidth" => 400, "maxHeight" => 400 }]
+    ["http://iiif.io/api/image/2/level2.json", { "maxWidth" => 400, "maxHeight" => 400 }]
   end
 
   # Overides stacks image to provide fixed dimensions

--- a/app/models/stacks_image.rb
+++ b/app/models/stacks_image.rb
@@ -28,7 +28,7 @@ class StacksImage
   end
 
   def profile
-    'http://iiif.io/api/image/2/level2'
+    'http://iiif.io/api/image/2/level2.json'
   end
 
   def exist?

--- a/spec/models/restricted_image_spec.rb
+++ b/spec/models/restricted_image_spec.rb
@@ -23,6 +23,6 @@ RSpec.describe RestrictedImage do
   describe '#profile' do
     subject { instance.profile }
 
-    it { is_expected.to eq ['http://iiif.io/api/image/2/level2', { 'maxHeight' => 400, 'maxWidth' => 400 }] }
+    it { is_expected.to eq ['http://iiif.io/api/image/2/level2.json', { 'maxHeight' => 400, 'maxWidth' => 400 }] }
   end
 end

--- a/spec/models/stacks_image_spec.rb
+++ b/spec/models/stacks_image_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe StacksImage do
   describe 'profile' do
     subject { instance.profile }
 
-    it { is_expected.to eq 'http://iiif.io/api/image/2/level2' }
+    it { is_expected.to eq 'http://iiif.io/api/image/2/level2.json' }
   end
 
   describe '#restricted' do

--- a/spec/services/iiif_info_service_spec.rb
+++ b/spec/services/iiif_info_service_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe IiifInfoService do
       end
 
       it 'has the profile' do
-        expect(image_info['profile']).to eq 'http://iiif.io/api/image/2/level2'
+        expect(image_info['profile']).to eq 'http://iiif.io/api/image/2/level2.json'
       end
     end
 


### PR DESCRIPTION
From https://iiif.io/api/image/2.1/compliance/#indicating-compliance