### PR TITLE
Keep redis gem on v4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem 'dalli'
 gem 'retries'
 gem 'zipline', '~> 1.2'
 gem 'jwt'
-gem 'redis'
+gem 'redis', '< 5' # Keep redis gem on v4 until Redis on VM is updated to v7
 
 # connection_pool required for thread-safe operations in dalli >= 3.0
 # see https://github.com/petergoldstein/dalli/blob/v3.0.0/3.0-Upgrade.md

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,10 +290,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (5.0.5)
-      redis-client (>= 0.9.0)
-    redis-client (0.10.0)
-      connection_pool
+    redis (4.8.0)
     regexp_parser (2.6.0)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -446,7 +443,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.3)
   rails-controller-testing
-  redis
+  redis (< 5)
   retries
   rspec-rails (~> 5.0)
   rubocop (~> 0.50)


### PR DESCRIPTION
This will unblock dependency updates and deploys until Redis is updated and we can update Sidekiq to version 7. See: https://github.com/sul-dlss/operations-tasks/issues/3210#issuecomment-1302508219