### PR TITLE
Remove X-Frame-Options from files#show

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -14,6 +14,7 @@ class FileController < ApplicationController
     expires_in 10.minutes
     response.headers['Accept-Ranges'] = 'bytes'
     response.headers['Content-Length'] = current_file.content_length
+    response.headers.delete('X-Frame-Options')
 
     send_file current_file.path, disposition: disposition
   end


### PR DESCRIPTION
This will allow stacks to embed this file as an object without having to retrieve it via `fetch` and processes it with PDF.js. We can just use the browsers built in PDF renderer.