### PR TITLE
handling dimensions that are too large

### DIFF
--- a/app/models/projection.rb
+++ b/app/models/projection.rb
@@ -112,7 +112,7 @@ class Projection
   end
 
   def real_transformation
-    return transformation unless image.is_a? RestrictedImage
+    return transformation unless (image.is_a? RestrictedImage) || use_original_size?
 
     IIIF::Image::Transformation.new(
       region: transformation.region,
@@ -127,7 +127,7 @@ class Projection
     size = transformation.size
     case size
     when IIIF::Image::Size::BestFit
-      max_size = image.max_size(self)
+      max_size = max_image_size
       if size.width <= max_size.width && size.height <= max_size.height
         size
       else
@@ -139,4 +139,27 @@ class Projection
       size
     end
   end
+
+  # For a full image request, if the requested width and height are larger than the original image,
+  # this method will return true
+  def use_original_size?
+    size = transformation.size
+    max_size = image.max_tile_dimensions.call(self)
+    (size.is_a? IIIF::Image::Size::BestFit) && max_size.width < size.width && max_size.height < size.height
+  end
+
+  # The original restricted image function used max_size, but the StacksImage class does not have that method
+  # Since we are using the restricted image block for both RestrictedImage and StacksImage, we check
+  # which method is available
+  def max_image_size
+    image.respond_to?(:max_size) ? image.max_size(self) : dimensions_to_size(image.max_tile_dimensions.call(self))
+  end
+
+  # StacksImage has max_tile_dimensions, which returns dimensions
+  # We need to create a Size object in order to pass back to create the Iiif image object for image_source
+  def dimensions_to_size(dimensions)
+    IIIF::Image::Size::BestFit.new(dimensions.width, dimensions.height)
+  end
+
+
 end

--- a/app/models/projection.rb
+++ b/app/models/projection.rb
@@ -160,6 +160,4 @@ class Projection
   def dimensions_to_size(dimensions)
     IIIF::Image::Size::BestFit.new(dimensions.width, dimensions.height)
   end
-
-
 end

--- a/spec/models/projection_spec.rb
+++ b/spec/models/projection_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Projection do
     end
   end
 
-  describe '#tile_dimensions' do
+  describe '#tiledimensions' do
     subject { instance.send(:tile_dimensions) }
 
     context "for an unrestricted image" do
@@ -110,6 +110,18 @@ RSpec.describe Projection do
           allow(http_client).to receive(:get).and_return(double(body: nil))
           subject.response
           expect(http_client).to have_received(:get).with(%r{/full/max/0/default.jpg})
+        end
+      end
+
+      context "best fit size" do
+        let(:options) { { size: '!850,700', region: 'full' } }
+
+        it 'returns original size when requested dimensions are larger' do
+          allow(HTTP).to receive(:use)
+            .and_return(http_client)
+          allow(http_client).to receive(:get).and_return(double(body: nil))
+          subject.response
+          expect(http_client).to have_received(:get).with(%r{/full/!800,600/0/default.jpg})
         end
       end
     end

--- a/spec/models/projection_spec.rb
+++ b/spec/models/projection_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Projection do
     end
   end
 
-  describe '#tiledimensions' do
+  describe '#tile_dimensions' do
     subject { instance.send(:tile_dimensions) }
 
     context "for an unrestricted image" do


### PR DESCRIPTION
Closes https://github.com/sul-dlss/sul-embed/issues/1604 

What this pull request does:

- For requests that ask for an explicit width and height combination that is larger than the original image size, this code uses the original image size in the IIIF image request instead.  
- Code already existed to handle restricted images (which relate to user permissions).  That code has been updated and repurposed to check for this situation and use the original image size. 
- The type of image class seems to be different between the restricted image use case and these full size image requests.  The former has a different method for calculating image size, so the code checks which method is available and uses the appropriate one. 