### PR TITLE
File controller should check for download access

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -10,7 +10,7 @@ class FileController < ApplicationController
   def show
     return unless stale?(**cache_headers)
 
-    authorize! :read, current_file
+    authorize! :download, current_file
     expires_in 10.minutes
     response.headers['Accept-Ranges'] = 'bytes'
     response.headers['Content-Length'] = current_file.content_length
@@ -55,7 +55,7 @@ class FileController < ApplicationController
     {
       etag: [current_file.etag, current_user.try(:etag)],
       last_modified: current_file.mtime,
-      public: anonymous_ability.can?(:read, current_file),
+      public: anonymous_ability.can?(:download, current_file),
       template: false
     }
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -43,7 +43,7 @@ class Ability
 
     models = [StacksFile, StacksImage, StacksMediaStream]
 
-    can [:download, :read], models do |f|
+    can :download, models do |f|
       value, rule = f.rights.world_rights_for_file f.file_name
 
       value && (rule.nil? || rule != Dor::RightsAuth::NO_DOWNLOAD_RULE)
@@ -56,7 +56,7 @@ class Ability
     end
 
     if user.stanford?
-      can [:download, :read], models do |f|
+      can :download, models do |f|
         value, rule = f.rights.stanford_only_rights_for_file f.file_name
 
         value && (rule.nil? || rule != Dor::RightsAuth::NO_DOWNLOAD_RULE)
@@ -70,7 +70,7 @@ class Ability
     end
 
     if user.app_user?
-      can [:download, :read], models do |f|
+      can :download, models do |f|
         value, rule = f.rights.agent_rights_for_file f.file_name, user.id
 
         value && (rule.nil? || rule != Dor::RightsAuth::NO_DOWNLOAD_RULE)
@@ -84,7 +84,7 @@ class Ability
     end
 
     if user.locations.present?
-      can [:download, :read], models do |f|
+      can :download, models do |f|
         user.locations.any? do |location|
           value, rule = f.rights.location_rights_for_file(f.file_name, location)
           value && (rule.nil? || rule != Dor::RightsAuth::NO_DOWNLOAD_RULE)

--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -61,9 +61,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -88,9 +85,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -115,9 +109,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.not_to be_able_to(:read, big_image) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
@@ -143,9 +134,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.not_to be_able_to(:read, tile) }
       it { is_expected.not_to be_able_to(:stream, media) }
       it { is_expected.not_to be_able_to(:access, file) }
@@ -173,9 +161,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -199,9 +184,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.not_to be_able_to(:read, tile) }
       it { is_expected.not_to be_able_to(:stream, media) }
       it { is_expected.not_to be_able_to(:access, file) }
@@ -270,9 +252,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.not_to be_able_to(:read, tile) }
       it { is_expected.not_to be_able_to(:stream, media) }
       it { is_expected.not_to be_able_to(:access, file) }
@@ -317,9 +296,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -333,9 +309,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.not_to be_able_to(:read, tile) }
       it { is_expected.not_to be_able_to(:stream, media) }
       it { is_expected.not_to be_able_to(:access, file) }
@@ -361,9 +334,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -376,9 +346,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.not_to be_able_to(:read, tile) }
         it { is_expected.not_to be_able_to(:stream, media) }
         it { is_expected.not_to be_able_to(:access, file) }
@@ -407,9 +374,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -434,9 +398,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -461,9 +422,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -487,9 +445,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -513,9 +468,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -541,9 +493,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.to be_able_to(:download, file) }
       it { is_expected.to be_able_to(:download, image) }
       it { is_expected.to be_able_to(:download, media) }
-      it { is_expected.to be_able_to(:read, file) }
-      it { is_expected.to be_able_to(:read, image) }
-      it { is_expected.to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -567,9 +516,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.not_to be_able_to(:read, tile) }
       it { is_expected.not_to be_able_to(:stream, media) }
       it { is_expected.not_to be_able_to(:access, file) }
@@ -593,9 +539,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.not_to be_able_to(:read, tile) }
       it { is_expected.not_to be_able_to(:stream, media) }
       it { is_expected.not_to be_able_to(:access, file) }
@@ -619,9 +562,6 @@ RSpec.describe 'Ability', type: :model do
       it { is_expected.not_to be_able_to(:download, file) }
       it { is_expected.not_to be_able_to(:download, image) }
       it { is_expected.not_to be_able_to(:download, media) }
-      it { is_expected.not_to be_able_to(:read, file) }
-      it { is_expected.not_to be_able_to(:read, image) }
-      it { is_expected.not_to be_able_to(:read, media) }
       it { is_expected.to be_able_to(:read, tile) }
       it { is_expected.to be_able_to(:stream, media) }
       it { is_expected.to be_able_to(:access, file) }
@@ -654,9 +594,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.to be_able_to(:download, file) }
         it { is_expected.to be_able_to(:download, image) }
         it { is_expected.to be_able_to(:download, media) }
-        it { is_expected.to be_able_to(:read, file) }
-        it { is_expected.to be_able_to(:read, image) }
-        it { is_expected.to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -671,9 +608,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -690,9 +624,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.to be_able_to(:download, file) }
         it { is_expected.to be_able_to(:download, image) }
         it { is_expected.to be_able_to(:download, media) }
-        it { is_expected.to be_able_to(:read, file) }
-        it { is_expected.to be_able_to(:read, image) }
-        it { is_expected.to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -709,9 +640,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -728,9 +656,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.not_to be_able_to(:read, tile) }
         it { is_expected.not_to be_able_to(:stream, media) }
         it { is_expected.not_to be_able_to(:access, file) }
@@ -762,9 +687,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -779,9 +701,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.to be_able_to(:download, file) }
         it { is_expected.to be_able_to(:download, image) }
         it { is_expected.to be_able_to(:download, media) }
-        it { is_expected.to be_able_to(:read, file) }
-        it { is_expected.to be_able_to(:read, image) }
-        it { is_expected.to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -796,9 +715,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.not_to be_able_to(:read, tile) }
         it { is_expected.not_to be_able_to(:stream, media) }
         it { is_expected.not_to be_able_to(:access, file) }
@@ -828,9 +744,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -845,9 +758,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.to be_able_to(:download, file) }
         it { is_expected.to be_able_to(:download, image) }
         it { is_expected.to be_able_to(:download, media) }
-        it { is_expected.to be_able_to(:read, file) }
-        it { is_expected.to be_able_to(:read, image) }
-        it { is_expected.to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -882,9 +792,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.to be_able_to(:download, file) }
         it { is_expected.to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.to be_able_to(:read, file) }
-        it { is_expected.to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -920,9 +827,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.to be_able_to(:download, media) }
-        it { is_expected.to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.to be_able_to(:read, media) }
         it { is_expected.not_to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -940,9 +844,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.to be_able_to(:download, file) }
         it { is_expected.to be_able_to(:download, image) }
         it { is_expected.to be_able_to(:download, media) }
-        it { is_expected.to be_able_to(:read, file) }
-        it { is_expected.to be_able_to(:read, image) }
-        it { is_expected.to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }
@@ -956,9 +857,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.not_to be_able_to(:read, tile) }
         it { is_expected.not_to be_able_to(:stream, media) }
         it { is_expected.not_to be_able_to(:access, file) }
@@ -994,9 +892,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.to be_able_to(:download, image) }
         it { is_expected.to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.to be_able_to(:read, image) }
-        it { is_expected.to be_able_to(:read, media) }
         it { is_expected.to be_able_to(:read, tile) }
         it { is_expected.to be_able_to(:stream, media) }
         it { is_expected.not_to be_able_to(:access, file) }
@@ -1011,9 +906,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.not_to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.not_to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.not_to be_able_to(:read, tile) }
         it { is_expected.not_to be_able_to(:stream, media) }
         it { is_expected.not_to be_able_to(:access, file) }
@@ -1028,9 +920,6 @@ RSpec.describe 'Ability', type: :model do
         it { is_expected.to be_able_to(:download, file) }
         it { is_expected.not_to be_able_to(:download, image) }
         it { is_expected.not_to be_able_to(:download, media) }
-        it { is_expected.to be_able_to(:read, file) }
-        it { is_expected.not_to be_able_to(:read, image) }
-        it { is_expected.not_to be_able_to(:read, media) }
         it { is_expected.not_to be_able_to(:read, tile) }
         it { is_expected.not_to be_able_to(:stream, media) }
         it { is_expected.to be_able_to(:access, file) }


### PR DESCRIPTION
Then we can completely remove :read access for StacksFiles.  This removes a bunch of redundant actions from the Ability class. 