### PR TITLE
Remove unused basic auth path

### DIFF
--- a/app/controllers/concerns/current_user_concern.rb
+++ b/app/controllers/concerns/current_user_concern.rb
@@ -6,9 +6,7 @@ module CurrentUserConcern
   include ActionController::HttpAuthentication::Token
 
   def current_user
-    @current_user ||= if has_basic_credentials?(request)
-                        basic_auth_user
-                      elsif has_bearer_credentials?(request)
+    @current_user ||= if has_bearer_credentials?(request)
                         bearer_auth_user
                       elsif has_bearer_cookie?
                         bearer_cookie_user
@@ -24,13 +22,6 @@ module CurrentUserConcern
   end
 
   private
-
-  def basic_auth_user
-    user_name, password = user_name_and_password(request)
-    credentials = Settings.app_users[user_name]
-
-    User.new(id: user_name, app_user: true) if credentials && credentials == password
-  end
 
   def bearer_auth_user
     token, _options = token_and_options(request)

--- a/app/controllers/iiif_token_controller.rb
+++ b/app/controllers/iiif_token_controller.rb
@@ -50,7 +50,6 @@ class IiifTokenController < ApplicationController
   def token_eligible_user?
     current_user.token_user? ||
       current_user.webauth_user? ||
-      current_user.app_user? ||
       current_user.location? ||
       current_user.cdl_tokens.any?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@
 class User
   include ActiveModel::Model
 
-  attr_accessor :id, :webauth_user, :anonymous_locatable_user, :app_user, :token_user,
+  attr_accessor :id, :webauth_user, :anonymous_locatable_user, :token_user,
                 :ldap_groups, :ip_address, :jwt_tokens
 
   def ability
@@ -22,10 +22,6 @@ class User
 
   def stanford?
     ldap_groups.present? && (ldap_groups & Settings.user.stanford_groups).any?
-  end
-
-  def app_user?
-    app_user
   end
 
   def token_user?

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,3 @@
-app_users:
-  test-user: 'password'
-
 user:
   locations:
     location1:

--- a/spec/abilities/ability_spec.rb
+++ b/spec/abilities/ability_spec.rb
@@ -345,32 +345,6 @@ RSpec.describe 'Ability', type: :model do
     end
   end
 
-  context 'for an app user' do
-    let(:user) { User.new(id: 'a', app_user: true) }
-
-    context 'with an unrestricted file' do
-      let(:rights_xml) do
-        <<-EOF.strip_heredoc
-        <rightsMetadata>
-            <access type="read">
-              <machine>
-                <world />
-              </machine>
-            </access>
-          </rightsMetadata>
-        EOF
-      end
-      it { is_expected.to be_able_to(:download, file) }
-      it { is_expected.to be_able_to(:download, image) }
-      it { is_expected.to be_able_to(:read, tile) }
-      it { is_expected.to be_able_to(:stream, media) }
-      it { is_expected.to be_able_to(:access, file) }
-      it { is_expected.to be_able_to(:read_metadata, image) }
-      it { is_expected.to be_able_to(:read, thumbnail) }
-      it { is_expected.to be_able_to(:read, square_thumbnail) }
-    end
-  end
-
   context 'for an anonymous user' do
     context 'with a world-readable file' do
       let(:rights_xml) do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -6,19 +6,6 @@ RSpec.describe ApplicationController do
   describe '#current_user' do
     subject { controller.send(:current_user) }
 
-    context 'with an HTTP_AUTHORIZATION header' do
-      let(:credentials) { ActionController::HttpAuthentication::Basic.encode_credentials('test-user', 'password') }
-
-      before do
-        request.env['HTTP_AUTHORIZATION'] = credentials
-      end
-
-      it 'supports basic auth users' do
-        expect(subject.id).to eq 'test-user'
-        expect(subject).to be_a_app_user
-      end
-    end
-
     context 'with a Bearer token' do
       let(:user) { User.new(id: 'test-user', ldap_groups: ['stanford:stanford']) }
       let(:credentials) do

--- a/spec/controllers/iiif_controller_spec.rb
+++ b/spec/controllers/iiif_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe IiifController do
   end
 
   describe '#metadata' do
-    let(:anon_user) { instance_double(User, stanford?: false, app_user?: false, locations: [], cdl_tokens: []) }
+    let(:anon_user) { instance_double(User, stanford?: false, locations: [], cdl_tokens: []) }
 
     before do
       # for the cache headers


### PR DESCRIPTION
This was used many years ago, but it's no longer useful as SDR has no agent-level access