### PR TITLE
Run container in development env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,21 +8,11 @@ RUN apk add --update --no-cache  \
 
 WORKDIR /app
 
-ENV RAILS_ENV="production" \
-    BUNDLER_WITHOUT="development test" \
-    RAILS_SERVE_STATIC_FILES="true"
-
 COPY Gemfile Gemfile.lock ./
 
 RUN bundle install
 
 COPY . .
 
-# Precompile bootsnap code for faster boot times
-RUN bundle exec bootsnap precompile --gemfile app/ lib/
-
-# Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 bundle exec rails assets:precompile
-
 EXPOSE 3000
-CMD ["./bin/rails", "server"]
+CMD ["./bin/rails", "server", "--binding=0.0.0.0"]


### PR DESCRIPTION
We do this so Stacks can serve files (caption files, media files, etc.) directly without needing e.g. Wowza or passenger