### PR TITLE
Add cors headers for file show method

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -7,6 +7,8 @@ class FileController < ApplicationController
     render plain: 'File not found', status: :not_found
   end
 
+  before_action :set_cors_headers, only: [:show], if: proc { current_file.stacks_rights.stanford_restricted? }
+
   # rubocop:disable Metrics/AbcSize
   def show
     return unless stale?(**cache_headers)


### PR DESCRIPTION
Basically adds the CORs header to any request to show a file (not just media auth requests, as is current).

Fixes #1066