### PR TITLE
deal with encoded spaces in filenames

### DIFF
--- a/app/controllers/iiif/auth/v2/probe_service_controller.rb
+++ b/app/controllers/iiif/auth/v2/probe_service_controller.rb
@@ -50,15 +50,15 @@ module Iiif
         end
         # rubocop:enable Metrics/AbcSize
 
-        # parse the stacks resource URI by taking just full path, removing the '/file/' and then separating druid from filename (with paths)
+        # We expect the incoming stacks URI param to be URI encoded and we then
+        # parse the stacks URI by removing the '/file/druid:' and then separating druid from filename (with paths)
         def parse_uri(uri)
-          uri_parts = begin
-            URI(uri).path.delete_prefix('/file/').split('/')
+          obj = begin
+            URI(uri)
           rescue URI::InvalidURIError
             raise ActionDispatch::Http::Parameters::ParseError
           end
-          druid = uri_parts.first.delete_prefix('druid:')
-          file_name = uri_parts[1..].join('/').gsub(/(\+|%20)/, ' ')
+          druid, file_name = URI.decode_uri_component(obj.path.delete_prefix('/file/druid:')).split('/', 2)
           { druid:, file_name: }
         end
       end

--- a/app/controllers/iiif/auth/v2/probe_service_controller.rb
+++ b/app/controllers/iiif/auth/v2/probe_service_controller.rb
@@ -17,7 +17,9 @@ module Iiif
 
           response = { '@context': 'http://iiif.io/api/auth/2/context.json', type: 'AuthProbeResult2' }
 
-          if can? :access, file
+          if !file.readable?
+            response[:status] = 404
+          elsif can? :access, file
             response[:status] = 200
           else
             response[:status] = 401
@@ -56,7 +58,7 @@ module Iiif
             raise ActionDispatch::Http::Parameters::ParseError
           end
           druid = uri_parts.first.delete_prefix('druid:')
-          file_name = uri_parts[1..].join('/')
+          file_name = uri_parts[1..].join('/').gsub(/(\+|%20)/, ' ')
           { druid:, file_name: }
         end
       end

--- a/spec/requests/iiif/auth/v2/probe_service_spec.rb
+++ b/spec/requests/iiif/auth/v2/probe_service_spec.rb
@@ -5,8 +5,8 @@ require 'rails_helper'
 RSpec.describe 'IIIF auth v2 probe service' do
   let(:id) { 'bb461xx1037' }
   let(:file_name) { 'SC0193_1982-013_b06_f01_1981-09-29.pdf' }
-  let(:stacks_uri) { "https://stacks-uat.stanford.edu/file/druid:#{id}/#{CGI.escape(file_name)}" }
-  let(:stacks_uri_param) { CGI.escape(stacks_uri) }
+  let(:stacks_uri) { "https://stacks-uat.stanford.edu/file/druid:#{id}/#{URI.encode_uri_component(file_name)}" }
+  let(:stacks_uri_param) { URI.encode_uri_component(stacks_uri) }
   let(:public_json) { '{}' }
 
   # NOTE: For any unauthorized responses, the status from the service is OK...the access status of the resource is in the response body
@@ -69,21 +69,7 @@ RSpec.describe 'IIIF auth v2 probe service' do
       end
     end
 
-    context 'when filename with space encoded with %20' do
-      let(:file_name) { 'SC0193 1982-013 b06 f01 1981-09-29.pdf' }
-      let(:stacks_uri_param) { CGI.escape('https://stacks-uat.stanford.edu/file/druid:bb461xx1037/this%20is%20.pdf') }
-
-      it 'returns a success response' do
-        expect(response).to have_http_status :ok
-        expect(response.parsed_body).to include({
-                                                  "@context" => "http://iiif.io/api/auth/2/context.json",
-                                                  "type" => "AuthProbeResult2",
-                                                  "status" => 200
-                                                })
-      end
-    end
-
-    context 'when filename with space encoded with +' do
+    context 'when filename with spaces' do
       let(:file_name) { 'SC0193 1982-013 b06 f01 1981-09-29.pdf' }
 
       it 'returns a success response' do

--- a/spec/requests/iiif/auth/v2/probe_service_spec.rb
+++ b/spec/requests/iiif/auth/v2/probe_service_spec.rb
@@ -5,13 +5,16 @@ require 'rails_helper'
 RSpec.describe 'IIIF auth v2 probe service' do
   let(:id) { 'bb461xx1037' }
   let(:file_name) { 'SC0193_1982-013_b06_f01_1981-09-29.pdf' }
-  let(:stacks_uri) { CGI.escape "https://stacks-uat.stanford.edu/file/druid:#{id}/#{file_name}" }
+  let(:stacks_uri) { "https://stacks-uat.stanford.edu/file/druid:#{id}/#{CGI.escape(file_name)}" }
+  let(:stacks_uri_param) { CGI.escape(stacks_uri) }
   let(:public_json) { '{}' }
 
   # NOTE: For any unauthorized responses, the status from the service is OK...the access status of the resource is in the response body
 
+  # rubocop:disable RSpec/AnyInstance
   before do
     allow(Purl).to receive(:public_json).and_return(public_json)
+    allow_any_instance_of(StacksFile).to receive(:readable?).and_return('420')
   end
 
   context 'when the URI is not properly encoded' do
@@ -52,15 +55,62 @@ RSpec.describe 'IIIF auth v2 probe service' do
 
     before do
       stub_rights_xml(world_readable_rights_xml)
-      get "/iiif/auth/v2/probe?id=#{stacks_uri}"
+      get "/iiif/auth/v2/probe?id=#{stacks_uri_param}"
     end
 
-    it 'returns a success response' do
+    context 'when filename without spaces' do
+      it 'returns a success response' do
+        expect(response).to have_http_status :ok
+        expect(response.parsed_body).to include({
+                                                  "@context" => "http://iiif.io/api/auth/2/context.json",
+                                                  "type" => "AuthProbeResult2",
+                                                  "status" => 200
+                                                })
+      end
+    end
+
+    context 'when filename with space encoded with %20' do
+      let(:file_name) { 'SC0193 1982-013 b06 f01 1981-09-29.pdf' }
+      let(:stacks_uri_param) { CGI.escape('https://stacks-uat.stanford.edu/file/druid:bb461xx1037/this%20is%20.pdf') }
+
+      it 'returns a success response' do
+        expect(response).to have_http_status :ok
+        expect(response.parsed_body).to include({
+                                                  "@context" => "http://iiif.io/api/auth/2/context.json",
+                                                  "type" => "AuthProbeResult2",
+                                                  "status" => 200
+                                                })
+      end
+    end
+
+    context 'when filename with space encoded with +' do
+      let(:file_name) { 'SC0193 1982-013 b06 f01 1981-09-29.pdf' }
+
+      it 'returns a success response' do
+        expect(response).to have_http_status :ok
+        expect(response.parsed_body).to include({
+                                                  "@context" => "http://iiif.io/api/auth/2/context.json",
+                                                  "type" => "AuthProbeResult2",
+                                                  "status" => 200
+                                                })
+      end
+    end
+  end
+
+  context 'when the requested file does not exist' do
+    let(:public_json) { {} }
+
+    before do
+      allow_any_instance_of(StacksFile).to receive(:readable?).and_return(nil)
+      get "/iiif/auth/v2/probe?id=#{stacks_uri_param}"
+    end
+
+    it 'returns a 404 response' do
       expect(response).to have_http_status :ok
       expect(response.parsed_body).to include({
                                                 "@context" => "http://iiif.io/api/auth/2/context.json",
                                                 "type" => "AuthProbeResult2",
-                                                "status" => 200
+                                                "status" => 404
                                               })
     end
   end
@@ -92,14 +142,13 @@ RSpec.describe 'IIIF auth v2 probe service' do
       stub_rights_xml(stanford_restricted_rights_xml)
     end
 
-    # rubocop:disable RSpec/AnyInstance
     context 'when the user is logged in as a Stanford user' do
       let(:user_webauth_stanford_no_loc) { User.new(webauth_user: true, ldap_groups: %w[stanford:stanford]) }
       let(:current_user) { user_webauth_stanford_no_loc }
 
       before do
         allow_any_instance_of(Iiif::Auth::V2::ProbeServiceController).to receive(:current_user).and_return(current_user)
-        get "/iiif/auth/v2/probe?id=#{stacks_uri}"
+        get "/iiif/auth/v2/probe?id=#{stacks_uri_param}"
       end
 
       it 'returns a success response' do
@@ -111,11 +160,10 @@ RSpec.describe 'IIIF auth v2 probe service' do
                                                 })
       end
     end
-    # rubocop:enable RSpec/AnyInstance
 
     context 'when the user is not logged in as a Stanford user' do
       before do
-        get "/iiif/auth/v2/probe?id=#{stacks_uri}"
+        get "/iiif/auth/v2/probe?id=#{stacks_uri_param}"
       end
 
       it 'returns a not authorized response' do
@@ -134,7 +182,7 @@ RSpec.describe 'IIIF auth v2 probe service' do
         let(:file_name) { 'folder/SC0193_1982-013_b06_f01_1981-09-29.pdf' }
 
         before do
-          get "/iiif/auth/v2/probe?id=#{stacks_uri}"
+          get "/iiif/auth/v2/probe?id=#{stacks_uri_param}"
         end
 
         it 'returns a not authorized response' do
@@ -189,7 +237,7 @@ RSpec.describe 'IIIF auth v2 probe service' do
 
     before do
       stub_rights_xml(rights_xml)
-      get "/iiif/auth/v2/probe?id=#{stacks_uri}"
+      get "/iiif/auth/v2/probe?id=#{stacks_uri_param}"
     end
 
     context 'when special collections' do
@@ -271,7 +319,7 @@ RSpec.describe 'IIIF auth v2 probe service' do
 
     before do
       stub_rights_xml(rights_xml)
-      get "/iiif/auth/v2/probe?id=#{stacks_uri}"
+      get "/iiif/auth/v2/probe?id=#{stacks_uri_param}"
     end
 
     it 'returns a not authorized response' do
@@ -330,7 +378,7 @@ RSpec.describe 'IIIF auth v2 probe service' do
 
     before do
       stub_rights_xml(rights_xml)
-      get "/iiif/auth/v2/probe?id=#{stacks_uri}"
+      get "/iiif/auth/v2/probe?id=#{stacks_uri_param}"
     end
 
     it 'returns a not authorized response' do
@@ -344,4 +392,5 @@ RSpec.describe 'IIIF auth v2 probe service' do
                                               })
     end
   end
+  # rubocop:enable RSpec/AnyInstance
 end


### PR DESCRIPTION
1. When a filename in the URI has spaces in it, they need to be decoded properly (from the encoded filename) before constructing the StacksFile object so that the file can be found on disk.
2. If the file is not readable on stacks, return a 404 in the status of the response body.