### PR TITLE
allow probe service URLs to work even if druid: prefix is not provided in URI

### DIFF
--- a/app/controllers/iiif/auth/v2/probe_service_controller.rb
+++ b/app/controllers/iiif/auth/v2/probe_service_controller.rb
@@ -68,8 +68,9 @@ module Iiif
           rescue URI::InvalidURIError
             raise ActionDispatch::Http::Parameters::ParseError
           end
-          druid, file_name = URI.decode_uri_component(obj.path.delete_prefix('/file/druid:')).split('/', 2)
-          { druid:, file_name: }
+          path_with_druid_and_filename = URI.decode_uri_component(obj.path.delete_prefix('/file/'))
+          druid, file_name = path_with_druid_and_filename.split('/', 2)
+          { druid: druid.delete_prefix('druid:'), file_name: }
         end
       end
     end


### PR DESCRIPTION
The IIIF manifest currently provides stacks URIs without a druid: prefix, this breaks our parsing, which expects it.

e.g. https://purl.stanford.edu/bh502xm3351/iiif3/manifest

has `https://stacks.stanford.edu/file/bh502xm3351/CAS_bh502xm3351.pdf` in the `items` node.  

This is a valid URI that provides the PDF, but if you call the auth service with it, you get a 404:

https://stacks.stanford.edu/iiif/auth/v2/probe?id=https://stacks.stanford.edu/file/bh502xm3351/CAS_bh502xm3351.pdf

This fixes it by allowing our parsing of incoming URIs to work without a druid: prefix.