### PR TITLE
Add a validator on stacks files

### DIFF
--- a/app/controllers/iiif/auth/v2/probe_service_controller.rb
+++ b/app/controllers/iiif/auth/v2/probe_service_controller.rb
@@ -7,7 +7,7 @@ module Iiif
       # Check access for IIIF auth v2
       # https://iiif.io/api/auth/2.0/#probe-service
       class ProbeServiceController < ApplicationController
-        def show
+        def show # rubocop:disable Metrics:AbcSize
           # Example call:
           # /iiif/auth/v2/probe?id=https://stacks-uat.stanford.edu/file/druid:bb461xx1037/folder/SC0193_1982-013_b06_f01_1981-09-29.pdf
           stacks_uri = params[:id] # this is a fully qualified URI to the resource on the stacks that the user is requesting access to
@@ -17,7 +17,10 @@ module Iiif
 
           json = { '@context': 'http://iiif.io/api/auth/2/context.json', type: 'AuthProbeResult2' }
 
-          if !file.readable?
+          if !file.valid?
+            json[:status] = 400
+            json[:note] = { "en": file.errors.full_messages }
+          elsif !file.readable?
             json[:status] = 404
           elsif can? :access, file
             json[:status] = 200

--- a/app/models/stacks_file.rb
+++ b/app/models/stacks_file.rb
@@ -5,8 +5,11 @@
 # may be the file that backs a StacksImage or StacksMediaStream
 class StacksFile
   include ActiveModel::Model
+  include ActiveModel::Validations
 
   attr_accessor :id, :file_name, :current_ability, :download
+
+  validates :id, format: { with: /\A[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}\z/i }
 
   # Some files exist but have unreadable permissions, treat these as non-existent
   def readable?

--- a/spec/requests/iiif/auth/v2/probe_service_spec.rb
+++ b/spec/requests/iiif/auth/v2/probe_service_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe 'IIIF auth v2 probe service' do
     end
   end
 
+  context "when the passed in uri isn't formatted correctly" do
+    let(:id) { '111' }
+
+    before do
+      get "/iiif/auth/v2/probe?id=#{stacks_uri}"
+    end
+
+    it 'returns a success response' do
+      expect(response).to have_http_status :ok
+      expect(response.parsed_body).to eq("@context" => "http://iiif.io/api/auth/2/context.json",
+                                         "note" => { "en" => ["Id is invalid"] },
+                                         "status" => 400,
+                                         "type" => "AuthProbeResult2")
+    end
+  end
+
   context 'when the user has access to the resource because it is world accessible' do
     let(:public_json) do
       {


### PR DESCRIPTION
This will give us a better message if the druid: prefix should sneak in