### PR TITLE
Set cookies SameSite=None

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,10 @@ module DigitalStacks
                              "172.20.21.208/28", # foa_lb_mgmt_dev_nets
                              "172.20.21.192/28" # foa_lb_mgmt_prod_nets
                            ].map { |proxy| IPAddr.new(proxy) }
+
+
+    # IIIF Auth v2 makes a request in one window to login and then opens a iframe to get a token.
+    # In order for this second request to know who the user is, the session token must created with SameSite=None
+    config.action_dispatch.cookies_same_site_protection = :none
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
This allows sul-embed to open an iframe to stacks and it will have the stacks session cookie passed with the request.

We have to do this because Chrome and safari now default to Lax, which doesn't allow us to do the behavior we want.  In order to use SameSite=None, you also must mark the cookie Secure.