### PR TITLE
Avoid accessing secret__key_base via secrets

### DIFF
--- a/app/models/stacks_media_token.rb
+++ b/app/models/stacks_media_token.rb
@@ -106,7 +106,7 @@ class StacksMediaToken
 
   def self.encryptor
     salt = 'media'
-    key = ActiveSupport::KeyGenerator.new(Rails.application.secrets.secret_key_base).generate_key(salt, 32)
+    key = ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base).generate_key(salt, 32)
     ActiveSupport::MessageEncryptor.new(key)
   end
   private_class_method :encryptor

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,7 +70,7 @@ class User
 
   def self.encryptor
     salt = 'user'
-    key = ActiveSupport::KeyGenerator.new(Rails.application.secrets.secret_key_base).generate_key(salt, 32)
+    key = ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base).generate_key(salt, 32)
     ActiveSupport::MessageEncryptor.new(key)
   end
 


### PR DESCRIPTION
Rails.application.secrets is deprecated and issues a bunch of warnings.