### PR TITLE
Set the active_job test adapter

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.active_job.queue_adapter = :test
 end


### PR DESCRIPTION
This avoids running background jobs inline, which cause a bunch of WebMock errors to be logged