### PR TITLE
Remove unused routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,14 +16,12 @@ Rails.application.routes.draw do
       # File/auth routes without druid namespace
       get '/file/:id/*file_name' => 'file#show', as: :file
       options '/file/:id/*file_name', to: 'file#options'
-      get '/file/app/:id/*file_name' => 'webauth#login_file'
       get '/file/auth/:id/*file_name' => 'webauth#login_file', as: :auth_file
       get '/file/auth/:id' => 'webauth#login_object', as: :auth_object
 
       # File/auth routes with druid namespace
       get '/file/druid::id/*file_name' => 'file#show'
       options '/file/druid::id/*file_name', to: 'file#options'
-      get '/file/app/druid::id/*file_name' => 'webauth#login_file'
       get '/file/auth/druid::id/*file_name' => 'webauth#login_file'
       get '/file/auth/druid::id' => 'webauth#login_object'
     end

--- a/spec/routing/file_routing_spec.rb
+++ b/spec/routing/file_routing_spec.rb
@@ -60,9 +60,5 @@ RSpec.describe 'file routes' do
     it 'routes to webauth#login_file' do
       expect(get: '/file/auth/oo000oo0000/def.pdf').to route_to('webauth#login_file', id: 'oo000oo0000', file_name: 'def.pdf')
     end
-
-    it 'routes to webauth#login_file' do
-      expect(get: '/file/app/oo000oo0000/def.pdf').to route_to('webauth#login_file', id: 'oo000oo0000', file_name: 'def.pdf')
-    end
   end
 end


### PR DESCRIPTION
It seems these might have been from Agent auth restrictions, which were removed when the repository was converted to Cocina.