### PR TITLE
Remove dependency on zipline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem 'http'
 gem 'cancancan'
 gem 'dalli'
 gem 'retries'
-gem 'zipline', '~> 2.0'
+gem 'zip_kit', '~> 6.3'
 gem 'jwt'
 gem 'redis'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,6 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
     connection_pool (2.4.1)
-    content_disposition (1.0.0)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -394,10 +393,6 @@ GEM
       nokogiri (~> 1.8)
     zeitwerk (2.7.1)
     zip_kit (6.3.1)
-    zipline (2.0.0)
-      actionpack (>= 6.0, < 8.0)
-      content_disposition (~> 1.0)
-      zip_kit (~> 6, >= 6.2.0, < 7)
 
 PLATFORMS
   arm64-darwin-23
@@ -446,7 +441,7 @@ DEPENDENCIES
   web-console (>= 4.1.0)
   webdrivers
   webmock (~> 3.0)
-  zipline (~> 2.0)
+  zip_kit (~> 6.3)
 
 BUNDLED WITH
    2.5.14

--- a/app/models/cocina.rb
+++ b/app/models/cocina.rb
@@ -6,6 +6,7 @@ class Cocina
 
   THUMBNAIL_MIME_TYPE = 'image/jp2'
 
+  # @return [Cocina] Returns the cocina object for the given druid and version
   def self.find(druid, version = :head)
     data = Rails.cache.fetch(metadata_cache_key(druid, version), expires_in: 10.minutes) do
       benchmark "Fetching public json for #{druid} version #{version}" do
@@ -73,6 +74,7 @@ class Cocina
     data.dig('access', 'embargo', 'releaseDate')
   end
 
+  # @return [Enumerator<StacksFile>] when no block is passed
   def files(&)
     return to_enum(:files) unless block_given?
 


### PR DESCRIPTION
Because zipline is not yet compatable with the latest version of Rails.  It also has many features that we don't use. Fixes #1311