### PR TITLE
Restrict to modern browsers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 # :nodoc:
 class ApplicationController < ActionController::Base
+  allow_browser versions: :modern
   include CurrentUserConcern
 
   rescue_from CanCan::AccessDenied, with: :rescue_can_can


### PR DESCRIPTION
We have a lot of requests from stealth-bots that are overloading the imageserver and causing honeybadger alerts.  These bots often pretend to be a random version of Chrome.  By only allowing the modern versions of browsers, we remove a bunch of requests we don't care about. https://github.com/rails/rails/blob/e3cf59212be585df91e1f1ccc7b76d08fb28402b/actionpack/lib/action_controller/metal/allow_browser.rb\#L75