### PR TITLE
Return the token for the resource not for the user

### DIFF
--- a/app/controllers/iiif/auth/v2/probe_service_controller.rb
+++ b/app/controllers/iiif/auth/v2/probe_service_controller.rb
@@ -29,8 +29,10 @@ module Iiif
             if file.streamable?
               # See https://iiif.io/api/auth/2.0/#location
               json[:status] = 302
+
+              encrypted_token = file.encrypted_token(ip: request.remote_ip)
               json[:location] = {
-                id: "#{file.streaming_url}?stacks_token=#{URI.encode_uri_component(current_user.token)}",
+                id: "#{file.streaming_url}?stacks_token=#{URI.encode_uri_component(encrypted_token)}",
                 type: "Video"
               }
             else

--- a/app/models/stacks_file.rb
+++ b/app/models/stacks_file.rb
@@ -66,6 +66,12 @@ class StacksFile
     "#{Settings.stream.url}/#{storage_root.treeified_id}/#{streaming_url_file_segment}/playlist.m3u8"
   end
 
+  def encrypted_token(ip:)
+    # we use IP from which request originated -- we want the end user IP, not
+    #   a service on the user's behalf (load-balancer, etc.)
+    StacksMediaToken.new(id, file_name, ip).to_encrypted_string
+  end
+
   private
 
   def streaming_url_file_segment

--- a/app/models/stacks_media_stream.rb
+++ b/app/models/stacks_media_stream.rb
@@ -9,7 +9,7 @@ class StacksMediaStream
   end
   attr_accessor :stacks_file
 
-  delegate :etag, :mtime, :stacks_rights, to: :stacks_file
+  delegate :etag, :mtime, :stacks_rights, :encrypted_token, to: :stacks_file
 
   delegate :rights, :restricted_by_location?, :stanford_restricted?, :embargoed?,
            :embargo_release_date, :location, to: :stacks_rights

--- a/spec/controllers/media_controller_spec.rb
+++ b/spec/controllers/media_controller_spec.rb
@@ -118,15 +118,13 @@ RSpec.describe MediaController do
     end
 
     context 'success' do
-      let(:token) { instance_double(StacksMediaToken, to_encrypted_string: 'sekret-token') }
       before do
-        allow(StacksMediaToken).to receive(:new).and_return(token)
-
         # We could be more integration-y and instead e.g. stub_request(:get, "https://purl.stanford.edu/bd786fy6312.json").to_return(...).
         # But the StacksMediaStream code (and the metadata fetching/parsing code it uses) that'd be exercised by that approach is already
         # tested elsewhere. This approach is a bit more readable, and less brittle since it doesn't break the StacksMediaStream abstraction.
         stacks_media_stream = instance_double(StacksMediaStream, stanford_restricted?: false, restricted_by_location?: false,
-                                                                 embargoed?: false, embargo_release_date: nil)
+                                                                 embargoed?: false, embargo_release_date: nil,
+                                                                 encrypted_token: 'sekret-token')
         allow(controller).to receive_messages(can?: true, current_media: stacks_media_stream)
       end
 

--- a/spec/requests/media_headers_request_spec.rb
+++ b/spec/requests/media_headers_request_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "CORS headers for Media requests" do
 
   let(:public_json) do
     {
+      'externalIdentifier' => "druid:#{druid}",
       'structural' => {
         'contains' => [
           {


### PR DESCRIPTION
We were previously returning the wrong token in IIIF v2 auth