### PR TITLE
[refactor] Extract AuthProbeResult2 class

### DIFF
--- a/app/controllers/iiif/auth/v2/probe_service_controller.rb
+++ b/app/controllers/iiif/auth/v2/probe_service_controller.rb
@@ -7,39 +7,19 @@ module Iiif
       # Check access for IIIF auth v2
       # https://iiif.io/api/auth/2.0/#probe-service
       class ProbeServiceController < ApplicationController
-        def show # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
-          # Example call:
-          # /iiif/auth/v2/probe?id=https://stacks-uat.stanford.edu/file/druid:bb461xx1037/folder/SC0193_1982-013_b06_f01_1981-09-29.pdf
+        # Example call:
+        # /iiif/auth/v2/probe?id=https://stacks-uat.stanford.edu/file/druid:bb461xx1037/folder/SC0193_1982-013_b06_f01_1981-09-29.pdf
+        def show
           stacks_uri = params[:id] # this is a fully qualified URI to the resource on the stacks that the user is requesting access to
           parsed_uri = parse_uri(stacks_uri)
-
-          json = { '@context': 'http://iiif.io/api/auth/2/context.json', type: 'AuthProbeResult2' }
           begin
             cocina = Cocina.find(parsed_uri[:druid])
             file = StacksFile.new(file_name: parsed_uri[:file_name], cocina:)
           rescue Purl::Exception
-            return render json: json.merge(status: 404, note: { en: ["Unable to find #{parsed_uri[:druid]}"] })
+            return render json: AuthProbeResult2.not_found(parsed_uri[:druid])
           end
 
-          if !file.valid?
-            json[:status] = 400
-            json[:note] = { en: file.errors.full_messages }
-          elsif !file.readable?
-            json[:status] = 404
-          elsif can? :access, file
-            if file.streamable? || cocina.geo?
-              # See https://iiif.io/api/auth/2.0/#location
-              json[:status] = 302
-              json[:location] = iiif_location(cocina.geo?, file)
-            else
-              json[:status] = 200
-            end
-          else
-            json[:status] = 401
-            json.merge!(add_detail(file))
-          end
-
-          render json:
+          render json: auth_probe_result(file, cocina)
         end
 
         def iiif_location(is_geo, file)
@@ -68,24 +48,34 @@ module Iiif
 
         private
 
-        # add details to response for when access is denied
-        # rubocop:disable Metrics/AbcSize
-        def add_detail(file)
-          detail = {}
-          if file.stanford_restricted? && !file.embargoed?
-            detail[:heading] = { en: [I18n.t('probe_service.stanford')] }
-            detail[:auth_url] = iiif_auth_api_url
-          elsif file.stanford_restricted? && file.embargoed?
-            detail[:heading] = { en: [I18n.t('probe_service.stanford_and_embargoed', date: file.embargo_release_date.to_date)] }
-          elsif file.embargoed?
-            detail[:heading] = { en: [I18n.t('probe_service.embargoed', date: file.embargo_release_date.to_date)] }
-          elsif file.restricted_by_location?
-            detail[:heading] = { en: [I18n.t('probe_service.location', location: Settings.user.locations.labels.send(file.location))] }
+        def auth_probe_result(file, cocina)
+          if !file.valid?
+            AuthProbeResult2.bad_request(file.errors.full_messages)
+          elsif !file.readable?
+            AuthProbeResult2.not_found(cocina.druid)
+          elsif can? :access, file
+            if file.streamable? || cocina.geo?
+              AuthProbeResult2.redirect(iiif_location(cocina.geo?, file))
+            else
+              AuthProbeResult2.ok
+            end
+          else
+            AuthProbeResult2.unauthorized(unauthorized_heading(file))
           end
-          detail[:note] = { en: [I18n.t('probe_service.access_restricted')] }
-          detail
         end
-        # rubocop:enable Metrics/AbcSize
+
+        # add details to response for when access is denied
+        def unauthorized_heading(file)
+          if file.stanford_restricted? && !file.embargoed?
+            I18n.t('probe_service.stanford')
+          elsif file.stanford_restricted? && file.embargoed?
+            I18n.t('probe_service.stanford_and_embargoed', date: file.embargo_release_date.to_date)
+          elsif file.embargoed?
+            I18n.t('probe_service.embargoed', date: file.embargo_release_date.to_date)
+          elsif file.restricted_by_location?
+            I18n.t('probe_service.location', location: Settings.user.locations.labels.send(file.location))
+          end
+        end
 
         # We expect the incoming stacks URI param to be URI encoded and we then
         # parse the stacks URI by removing the '/file/druid:' and then separating druid from filename (with paths)

--- a/app/models/auth_probe_result2.rb
+++ b/app/models/auth_probe_result2.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Represents IIIF Auth V2 probe service response
+# See https://iiif.io/api/auth/2.0/#probe-service-response
+class AuthProbeResult2
+  def initialize(status:, note: nil)
+    @status = status
+    @note = note
+  end
+
+  attr_reader :status, :note
+
+  def as_json
+    json = { '@context': 'http://iiif.io/api/auth/2/context.json', type: 'AuthProbeResult2', status: status }
+    json[:note] = note if note
+    json
+  end
+
+  # When redirecting to a different resource.
+  class LocationResult < AuthProbeResult2
+    def initialize(location:, **)
+      super(status: 302)
+      @location = location
+    end
+
+    attr_reader :location
+
+    def as_json
+      super.merge(location:)
+    end
+  end
+
+  # When not authorized to view the resource.
+  class ErrorResult < AuthProbeResult2
+    def initialize(heading:, **)
+      super(status: 401, **)
+      @heading = heading
+    end
+
+    attr_reader :heading
+
+    def as_json
+      super.merge(heading:)
+    end
+  end
+
+  def self.ok
+    new(status: 200)
+  end
+
+  def self.bad_request(messages)
+    new(status: 400, note: { en: messages })
+  end
+
+  def self.unauthorized(heading)
+    ErrorResult.new(note: { en: [I18n.t('probe_service.access_restricted')] }, heading: { en: [heading] })
+  end
+
+  def self.not_found(druid)
+    new(status: 404, note: { en: ["Unable to find #{druid}"] })
+  end
+
+  # See https://iiif.io/api/auth/2.0/#location
+  def self.redirect(location)
+    LocationResult.new(location:)
+  end
+end

--- a/spec/requests/iiif/auth/v2/probe_service_spec.rb
+++ b/spec/requests/iiif/auth/v2/probe_service_spec.rb
@@ -198,7 +198,6 @@ RSpec.describe 'IIIF auth v2 probe service' do
                                                   "type" => "AuthProbeResult2",
                                                   "status" => 401,
                                                   "heading" => { "en" => ["Stanford users: log in to access all available features."] },
-                                                  "auth_url" => "http://www.example.com/auth/iiif",
                                                   "note" => { "en" => ["Access restricted"] }
                                                 })
       end
@@ -217,7 +216,6 @@ RSpec.describe 'IIIF auth v2 probe service' do
                                                     "type" => "AuthProbeResult2",
                                                     "status" => 401,
                                                     "heading" => { "en" => ["Stanford users: log in to access all available features."] },
-                                                    "auth_url" => "http://www.example.com/auth/iiif",
                                                     "note" => { "en" => ["Access restricted"] }
                                                   })
         end


### PR DESCRIPTION
This fixes the rubocop errors and separates the formatting of the response out of the controller. 

This also removes `auth_url`, which is not a valid property of the probe service response (https://iiif.io/api/auth/2.0/#probe-service-response) and was not used.