### PR TITLE
Move token generation into StacksMediaStream

### DIFF
--- a/app/controllers/iiif/auth/v2/probe_service_controller.rb
+++ b/app/controllers/iiif/auth/v2/probe_service_controller.rb
@@ -22,18 +22,15 @@ module Iiif
           render json: auth_probe_result(file, cocina)
         end
 
-        def iiif_location(is_geo, file)
+        def iiif_location(is_geo, stacks_file)
           if is_geo
             # 4 hour token
             token = JWT.encode({ data: 'geo_token', exp: Time.now.to_i + (4 * 3600) }, Settings.geo.proxy_secret, 'HS256')
-            url = Settings.geo.proxy_url
-            type = "Geo"
+            { id: "#{Settings.geo.proxy_url}?stacks_token=#{URI.encode_uri_component(token)}", type: 'Geo' }
           else
-            token = file.encrypted_token(ip: request.remote_ip)
-            url = file.streaming_url
-            type = "Video"
+            stream_url = StacksMediaStream.new(stacks_file:).streaming_url(ip: request.remote_ip)
+            { id: stream_url, type: 'Video' }
           end
-          { id: "#{url}?stacks_token=#{URI.encode_uri_component(token)}", type: }
         end
 
         # Because the probe request sets the Accept header, the browser is going to preflight the request.

--- a/app/models/stacks_file.rb
+++ b/app/models/stacks_file.rb
@@ -63,25 +63,4 @@ class StacksFile
     accepted_formats = [".mov", ".mp4", ".mpeg", ".m4a", ".mp3"]
     accepted_formats.include? File.extname(file_name)
   end
-
-  def streaming_url
-    "#{Settings.stream.url}/#{storage_root.treeified_id}/#{streaming_url_file_segment}/playlist.m3u8"
-  end
-
-  def encrypted_token(ip:)
-    # we use IP from which request originated -- we want the end user IP, not
-    #   a service on the user's behalf (load-balancer, etc.)
-    StacksMediaToken.new(id, file_name, ip).to_encrypted_string
-  end
-
-  private
-
-  def streaming_url_file_segment
-    case File.extname(file_name)
-    when '.mp3'
-      "mp3:#{file_name}"
-    else
-      "mp4:#{file_name}"
-    end
-  end
 end

--- a/app/models/stacks_media_stream.rb
+++ b/app/models/stacks_media_stream.rb
@@ -9,8 +9,31 @@ class StacksMediaStream
   end
   attr_accessor :stacks_file
 
-  delegate :etag, :mtime, :stacks_rights, :encrypted_token, :not_proxied?, to: :stacks_file
+  delegate :id, :file_name, :etag, :mtime, :stacks_rights, :not_proxied?, to: :stacks_file
 
   delegate :rights, :restricted_by_location?, :stanford_restricted?, :embargoed?,
            :embargo_release_date, :location, :world_viewable?, :no_download?, to: :stacks_rights
+
+  def streaming_url(ip:)
+    token = encrypted_token(ip:)
+    "#{Settings.stream.url}/#{stacks_file.storage_root.treeified_id}/" \
+      "#{streaming_url_file_segment}/playlist.m3u8?stacks_token=#{URI.encode_uri_component(token)}"
+  end
+
+  def encrypted_token(ip:)
+    # we use IP from which request originated -- we want the end user IP, not
+    #   a service on the user's behalf (load-balancer, etc.)
+    StacksMediaToken.new(id, file_name, ip).to_encrypted_string
+  end
+
+  private
+
+  def streaming_url_file_segment
+    case File.extname(file_name)
+    when '.mp3'
+      "mp3:#{file_name}"
+    else
+      "mp4:#{file_name}"
+    end
+  end
 end


### PR DESCRIPTION
This token is only used for media streams, so it oughtn't be in StacksFile