### PR TITLE
Retry on timeout errors

### DIFF
--- a/app/services/iiif_metadata_service.rb
+++ b/app/services/iiif_metadata_service.rb
@@ -43,7 +43,7 @@ class IiifMetadataService
 
   # @return [String] the IIIF info response
   def retrieve
-    with_retries max_tries: 3, rescue: [HTTP::ConnectionError] do
+    with_retries max_tries: 3, rescue: [HTTP::ConnectionError, HTTP::TimeoutError] do
       handle_response(
         # Disable url normalization as an upstream bug in addressable causes issues for `+`
         # https://github.com/sporkmonger/addressable/issues/386


### PR DESCRIPTION
TimeoutError does not extend from ConnectionError, so we need to add it too. See https://github.com/httprb/http/blob/1af3c8e2dfb84d73e7febaaffce7bd7f4829cced/lib/http/errors.rb\#L39C31-L39C43