### PR TITLE
fix degraded info.json to display correct dimensions, sizes

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -79,7 +79,8 @@ class IiifController < ApplicationController
       IiifInfoService.info(
         current_image,
         anonymous_ability.can?(:download, current_image),
-        self
+        self,
+        degraded?
       )
     )
   end
@@ -151,7 +152,10 @@ class IiifController < ApplicationController
   end
 
   def canonical_url
-    iiif_base_url(id: identifier_params[:id], file_name: identifier_params[:file_name], host: request.host_with_port)
+    base_url = iiif_base_url(id: identifier_params[:id], file_name: identifier_params[:file_name], host: request.host_with_port)
+    return base_url unless degraded?
+
+    base_url.gsub('/iiif/', '/iiif/degraded/')
   end
 
   def stacks_file

--- a/spec/services/iiif_info_service_spec.rb
+++ b/spec/services/iiif_info_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe IiifInfoService do
   describe '#info' do
     subject(:image_info) do
-      described_class.info(image, downloadable_anonymously, context)
+      described_class.info(image, downloadable_anonymously, context, degraded)
     end
 
     let(:context) do
@@ -20,6 +20,7 @@ RSpec.describe IiifInfoService do
     let(:public_json) { {} }
     let(:stacks_file) { StacksFile.new(file_name: 'nr349ct7889_00_0001', cocina:) }
     let(:source_info) { {} }
+    let(:degraded) { false }
 
     before do
       allow(image).to receive_messages(info: source_info,


### PR DESCRIPTION
part of #1422 


Before degraded info.json
![Screenshot 2025-03-28 at 2 10 52 PM](https://github.com/user-attachments/assets/b413fa35-9f4e-441c-a3da-41acc52a0c4b)

After
<img width="786" alt="Screenshot 2025-05-28 at 11 39 11 AM" src="https://github.com/user-attachments/assets/b772c1c1-0c8e-4f1d-ae6f-b3319d9cc835" />

