### PR TITLE
Revert "fix degraded info.json to display correct dimensions, sizes"

### DIFF
--- a/app/controllers/iiif_controller.rb
+++ b/app/controllers/iiif_controller.rb
@@ -79,8 +79,7 @@ class IiifController < ApplicationController
       IiifInfoService.info(
         current_image,
         anonymous_ability.can?(:download, current_image),
-        self,
-        degraded?
+        self
       )
     )
   end
@@ -152,10 +151,7 @@ class IiifController < ApplicationController
   end
 
   def canonical_url
-    base_url = iiif_base_url(id: identifier_params[:id], file_name: identifier_params[:file_name], host: request.host_with_port)
-    return base_url unless degraded?
-
-    base_url.gsub('/iiif/', '/iiif/degraded/')
+    iiif_base_url(id: identifier_params[:id], file_name: identifier_params[:file_name], host: request.host_with_port)
   end
 
   def stacks_file

--- a/app/services/iiif_info_service.rb
+++ b/app/services/iiif_info_service.rb
@@ -10,29 +10,27 @@ class IiifInfoService
   # @param downloadable_anonymously [Boolean] can the resource be downloaded anonymously?
   # @param context [IiifController] the context for the routing helpers (has hostname)
   # @return [Hash] a data structure to that expresses the info.json response
-  def self.info(current_image, downloadable_anonymously, context, degraded)
-    new(current_image, downloadable_anonymously, context, degraded).info
+  def self.info(current_image, downloadable_anonymously, context)
+    new(current_image, downloadable_anonymously, context).info
   end
 
   # @param current_image [StacksImage,RestrictedImage] the image to get the information for
   # @param downloadable_anonymously [Boolean] can the resource be downloaded anonymously?
   # @param context [IiifController] the context for the routing helpers (has hostname)
-  def initialize(current_image, downloadable_anonymously, context, degraded)
+  def initialize(current_image, downloadable_anonymously, context)
     @current_image = current_image
     @downloadable_anonymously = downloadable_anonymously
     @context = context
-    @degraded = degraded
   end
 
-  attr_reader :current_image, :downloadable_anonymously, :context, :degraded
+  attr_reader :current_image, :downloadable_anonymously, :context
 
   # @return [Hash] a data structure to that expresses the info.json response
   def info
     current_image.info.tap do |info|
       info['profile'] = current_image.profile
       info['sizes'] = sizes(info['sizes'])
-      info['height'] = height(info)
-      info['width'] = width(info)
+      info['sizes'] = thumbnail_only_size unless current_image.maybe_downloadable?
 
       service = services unless downloadable_anonymously
       info['service'] = service if service
@@ -40,24 +38,10 @@ class IiifInfoService
     end
   end
 
-  def width(info)
-    return info['width'] unless degraded
-
-    info['sizes'].first[:width]
-  end
-
-  def height(info)
-    return info['height'] unless degraded
-
-    info['sizes'].first[:height]
-  end
-
   ##
   # Trims the provided sizes so that known large undownloadable sizes are not
   # returned
   def sizes(sizes)
-    return thumbnail_only_size unless current_image.maybe_downloadable? && !degraded
-
     sizes.to_a.filter do |size|
       size['width'].to_f * size['height'].to_f < MAX_SIZE_ALLOWED
     end

--- a/spec/requests/iiif_spec.rb
+++ b/spec/requests/iiif_spec.rb
@@ -6,15 +6,17 @@ RSpec.describe 'IIIF API' do
   let(:metadata) do
     { 'height' => 2099,
       'width' => 1702,
-      'sizes' => [{ 'width' => 1702, 'height' => 2099 }],
       'tiles' => [{ 'width' => 256, "height" => 256, "scaleFactors" => [1, 2, 4, 8, 16] }] }
+  end
+  let(:metadata_service) do
+    instance_double(IiifMetadataService, fetch: metadata,
+                                         image_width: 1702,
+                                         image_height: 2552)
   end
 
   before do
     allow(Cocina).to receive(:find).and_return(Cocina.new(public_json))
-    stub_request(:get, "http://imageserver-prod.stanford.edu/iiif/2/bb%2F000%2Fcr%2F7262%2Fbb000cr7262%2Fcontent%2F8ff299eda08d7c506273840d52a03bf3/info.json").to_return(
-      status: 200, body: metadata.to_json
-    )
+    allow(IiifMetadataService).to receive(:new).and_return(metadata_service)
   end
 
   context 'with versioned file layout' do
@@ -120,8 +122,6 @@ RSpec.describe 'IIIF API' do
             get '/image/iiif/degraded/bb000cr7262/image/info.json'
 
             expect(response).to have_http_status :ok
-            expect(response.parsed_body['@id']).to eq 'http://www.example.com/image/iiif/degraded/bb000cr7262/image'
-            expect(response.parsed_body['sizes']).to eq [{ "height" => 400, "width" => 324 }]
             expect(controller.send(:current_image).stacks_file.id).to eq 'bb000cr7262'
           end
         end
@@ -141,7 +141,7 @@ RSpec.describe 'IIIF API' do
           get '/image/iiif/bb000cr7262%2Fimage/info.json'
           json = response.parsed_body
 
-          expect(json['sizes']).to eq [{ 'width' => 324, 'height' => 400 }]
+          expect(json['sizes']).to eq [{ 'width' => 266, 'height' => 400 }]
         end
       end
 
@@ -202,7 +202,7 @@ RSpec.describe 'IIIF API' do
 
       context 'when the object has no filesets (e.g. a collection)' do
         let(:public_json) do
-          { 'structural' => { 'contains' => [] } }
+          { 'structural' => {} }
         end
 
         it 'returns 404 Not Found' do

--- a/spec/services/iiif_info_service_spec.rb
+++ b/spec/services/iiif_info_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe IiifInfoService do
   describe '#info' do
     subject(:image_info) do
-      described_class.info(image, downloadable_anonymously, context, degraded)
+      described_class.info(image, downloadable_anonymously, context)
     end
 
     let(:context) do
@@ -20,7 +20,6 @@ RSpec.describe IiifInfoService do
     let(:public_json) { {} }
     let(:stacks_file) { StacksFile.new(file_name: 'nr349ct7889_00_0001', cocina:) }
     let(:source_info) { {} }
-    let(:degraded) { false }
 
     before do
       allow(image).to receive_messages(info: source_info,


### PR DESCRIPTION
This reverts commit 7b41052c11dbc86d7db02012e2f55a49acd3e461.

For some reason it is only showing portions of the image 
<img width="947" height="491" alt="Screenshot 2025-10-01 at 11 22 00 AM" src="https://github.com/user-attachments/assets/5ee0181b-5585-4fb1-aadb-e89b27c90799" />
