### PR TITLE
Add a special error when we have 502

### DIFF
--- a/app/services/iiif_metadata_service.rb
+++ b/app/services/iiif_metadata_service.rb
@@ -58,6 +58,8 @@ class IiifMetadataService
       conn.body
     when 503
       raise Stacks::ImageServerUnavailable, "Unable to reach image server (503 Service Unavailable) for #{@url}."
+    when 502
+      raise Stacks::ImageServerBadGateway, "Unable to reach image server (502 Bad Gateway) for #{@url}."
     else
       raise Stacks::RetrieveMetadataError, "There was a problem fetching #{@url}. Server returned #{conn.code}"
     end

--- a/lib/stacks.rb
+++ b/lib/stacks.rb
@@ -12,4 +12,8 @@ module Stacks
   # ImageServerUnavailable is raised when the image server returns
   # 503 Service Unavailable
   class ImageServerUnavailable < RetrieveMetadataError; end
+
+  # ImageServerUnavailable is raised when the load balancer returns
+  # 502 Bad Gateway
+  class ImageServerBadGateway < RetrieveMetadataError; end
 end


### PR DESCRIPTION
Otherwise these are coded as RetrieveMetadataError, which doesn't make it clear that this is an error coming from the load balancer