### PR TITLE
Memoize the IIIF image response

### DIFF
--- a/app/models/iiif_image.rb
+++ b/app/models/iiif_image.rb
@@ -18,13 +18,7 @@ class IiifImage
   # Get the image data from the remote server
   # @return [IO]
   def response
-    with_retries max_tries: 3, rescue: [HTTP::ConnectionError] do
-      benchmark "Fetch #{image_url}" do
-        HTTP.timeout(connect: 15, read_timeout: 5.minutes)
-            .headers(user_agent: "#{HTTP::Request::USER_AGENT} (#{Settings.user_agent})")
-            .get(image_url)
-      end
-    end
+    @response ||= retrieve
   end
 
   private
@@ -35,6 +29,16 @@ class IiifImage
 
   def image_url
     image_uri.to_s
+  end
+
+  def retrieve
+    with_retries max_tries: 3, rescue: [HTTP::ConnectionError] do
+      benchmark "Fetch #{image_url}" do
+        HTTP.timeout(connect: 15, read_timeout: 5.minutes)
+            .headers(user_agent: "#{HTTP::Request::USER_AGENT} (#{Settings.user_agent})")
+            .get(image_url)
+      end
+    end
   end
 
   attr_reader :transformation, :stacks_file


### PR DESCRIPTION
We are currently making duplicate requests to the image servers:
https://github.com/sul-dlss/stacks/blob/2a19c630cc687f9c9adacc0f611803229e93fa01/app/controllers/iiif_controller.rb#L35-L36

Access logs on the image servers confirm this.