### PR TITLE
Cache the json response for 5 minutes

### DIFF
--- a/app/services/iiif_metadata_service.rb
+++ b/app/services/iiif_metadata_service.rb
@@ -66,7 +66,7 @@ class IiifMetadataService
   end
 
   def json
-    @json ||= begin
+    @json ||= Rails.cache.fetch(cache_key, expires_in: 5.minutes) do
       retrieved_json = retrieve
       JSON.parse(retrieved_json).tap do |data|
         data['@id'] = @canonical_url
@@ -74,5 +74,9 @@ class IiifMetadataService
     rescue JSON::ParserError => e
       raise Stacks::UnexpectedMetadataResponseError, "There was a problem fetching #{@url}. #{e}: #{retrieved_json}"
     end
+  end
+
+  def cache_key
+    "iiif_metadata/#{Digest::SHA256.hexdigest(@url)}"
   end
 end


### PR DESCRIPTION
When a user visits a purl page, currently all initial requests are going through a single stacks node. This might not be intentional or dependable behavior (e.g., it could be a byproduct of specific load balancer configuration). 

However, for this case, caching the json response locally saves `n` info.json requests to the image servers, where `n` is the number of tiles being requested. Even in the worst case we are saving 1 request.