### PR TITLE
Memoize the s3 client

### DIFF
--- a/app/models/s3_client_factory.rb
+++ b/app/models/s3_client_factory.rb
@@ -2,13 +2,15 @@
 
 # Creates an S3 client instance.
 class S3ClientFactory
+  # rubocop:disable Naming/MemoizedInstanceVariableName
   def self.create_client
-    Aws::S3::Client.new(
+    @client ||= Aws::S3::Client.new(
       region: 'us-east-1',
       endpoint: Settings.s3.endpoint,
-      force_path_style: true, # Often required for custom endpoints
+      force_path_style: true,
       access_key_id: Settings.s3.access_key_id,
       secret_access_key: Settings.s3.secret_access_key
     )
   end
+  # rubocop:enable Naming/MemoizedInstanceVariableName
 end


### PR DESCRIPTION
Aws::S3::Client is explicitly designed to be shared across threads and requests.