### PR TITLE
File controller redirects to signed URLs

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -2,7 +2,6 @@
 
 ##
 # API for delivering files from stacks
-# rubocop:disable Metrics/ClassLength
 class FileController < ApplicationController
   include ActionController::Live
 
@@ -27,12 +26,7 @@ class FileController < ApplicationController
       ip: request.remote_ip
     )
 
-    # Handle range requests
-    if request.headers['Range'].present?
-      handle_range_request
-    else
-      handle_full_request
-    end
+    redirect_to current_file.signed_download_url, allow_other_host: true
   end
   # rubocop:enable Metrics/AbcSize
 
@@ -45,76 +39,6 @@ class FileController < ApplicationController
   end
 
   private
-
-  def handle_range_request # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    range_header = RangeHeader.new(request.headers['Range'], current_file.content_length)
-
-    if range_header.invalid?
-      # Invalid range, return 416 Range Not Satisfiable
-      response.headers['Content-Range'] = "bytes */#{current_file.content_length}"
-      head :range_not_satisfiable
-      return
-    end
-
-    # For simplicity, handle only single range requests
-    # Multi-range requests would require multipart/byteranges response
-    range = range_header.ranges.first
-
-    response.headers['Content-Range'] = "bytes #{range}/#{current_file.content_length}"
-    response.headers['Content-Length'] = range.content_length.to_s
-    if request.head?
-      set_head_response_headers
-      return head(:ok)
-    end
-
-    response.status = 206
-
-    send_stream(
-      filename: current_file.file_name,
-      type: current_file.content_type,
-      disposition:
-    ) do |stream|
-      current_file.s3_range(range: range.s3_range) do |chunk|
-        stream.write(chunk)
-      end
-    rescue StandardError => e
-      Honeybadger.notify(e)
-      raise
-    end
-  end
-
-  def handle_full_request
-    response.headers['Content-Length'] = current_file.content_length.to_s
-    if request.head?
-      set_head_response_headers
-      return head(:ok)
-    end
-
-    send_stream(
-      filename: current_file.file_name,
-      type: current_file.content_type,
-      disposition:
-    ) do |stream|
-      current_file.s3_object do |chunk|
-        stream.write(chunk)
-      end
-    rescue StandardError => e
-      Honeybadger.notify(e)
-      raise
-    end
-  end
-
-  def set_head_response_headers
-    response.headers['Content-Type'] = current_file.content_type
-    response.headers['Content-Disposition'] =
-      ActionDispatch::Http::ContentDisposition.format(disposition: disposition, filename: current_file.file_name)
-  end
-
-  def disposition
-    return :attachment if file_params[:download]
-
-    :inline
-  end
 
   def file_params
     params.permit(:id, :file_name, :download, :version_id)
@@ -153,4 +77,3 @@ class FileController < ApplicationController
     params[:version_id] || :head
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/stacks_file.rb
+++ b/app/models/stacks_file.rb
@@ -75,6 +75,19 @@ class StacksFile
     "weka/#{File.dirname(file_path)}/#{streaming_url_file_segment}"
   end
 
+  def signed_download_url
+    presigner = Aws::S3::Presigner.new(client: S3ClientFactory.create_client)
+    url = presigner.presigned_url(
+      :get_object,
+      bucket: Settings.s3.bucket,
+      key: s3_key,
+      expires_in: 3600
+    )
+    uri = URI(url)
+    uri.host = Settings.fileserver.host
+    uri
+  end
+
   def stacks_rights
     @stacks_rights ||= StacksRights.new(cocina:, file_name:)
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,9 @@ s3:
   bucket: stacks-test
   endpoint: https://sul-weka-s3.stanford.edu
 
+fileserver:
+  host: stacks.stanford.edu
+
 imageserver:
   base_uri: "http://imageserver-prod.stanford.edu/iiif/2/"
 

--- a/spec/requests/file_auth_request_spec.rb
+++ b/spec/requests/file_auth_request_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Authentication for File requests" do
         it 'allows when user webauthed and authorized' do
           allow_any_instance_of(FileController).to receive(:current_user).and_return(user_webauth_stanford_no_loc)
           get "/file/#{druid}/#{file_name}"
-          expect(response).to have_http_status(:ok)
+          expect(response).to redirect_to %r{^http://stacks.stanford.edu:9000/stacks-test/bb/000/cr/7262/bb000cr7262/content/8ff299eda08d7c506273840d52a03bf3\?X-Amz-Algorithm=AWS4-HMAC-SHA256}
         end
 
         it 'blocks when user webauthed but NOT authorized' do
@@ -56,7 +56,7 @@ RSpec.describe "Authentication for File requests" do
         it 'allows when user in location' do
           allow_any_instance_of(FileController).to receive(:current_user).and_return(user_loc_no_webauth)
           get "/file/#{druid}/#{file_name}"
-          expect(response).to have_http_status(:ok)
+          expect(response).to redirect_to %r{^http://stacks.stanford.edu:9000/stacks-test/bb/000/cr/7262/bb000cr7262/content/8ff299eda08d7c506273840d52a03bf3\?X-Amz-Algorithm=AWS4-HMAC-SHA256}
         end
 
         it 'blocks when user not in location' do

--- a/spec/requests/file_spec.rb
+++ b/spec/requests/file_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe "File requests" do
           .to_return(status: 200, body: public_json.to_json)
       end
 
-      it 'returns a successful HTTP response' do
+      it 'returns a redirect to the file server' do
         get "/v2/file/#{druid}/version/#{version_id}/#{file_name}"
-        expect(response).to be_successful
+        expect(response).to redirect_to %r{^http://stacks.stanford.edu:9000/stacks-test/bb/000/cr/7262/bb000cr7262/content/8ff299eda08d7c506273840d52a03bf3\?X-Amz-Algorithm=AWS4-HMAC-SHA256}
         expect(Cocina).to have_received(:find).with(druid, version_id)
       end
     end
@@ -62,14 +62,10 @@ RSpec.describe "File requests" do
       it 'sends headers for content' do
         get "/v2/file/#{druid}/version/#{version_id}/image.jp2", params: { download: 'any' }
 
-        expect(response).to be_successful
+        expect(response).to redirect_to %r{^http://stacks.stanford.edu:9000/stacks-test/bb/000/cr/7262/bb000cr7262/content/8ff299eda08d7c506273840d52a03bf3\?X-Amz-Algorithm=AWS4-HMAC-SHA256}
 
-        headers = response.headers.transform_keys(&:downcase)
-
-        expect(headers['content-disposition']).to include('attachment; filename="image.jp2"')
         expect(headers['accept-ranges']).to eq('bytes')
         expect(headers['access-control-expose-headers']).to eq('Content-Range')
-        expect(headers['content-length'].to_i).to be > 0
       end
     end
 
@@ -83,86 +79,10 @@ RSpec.describe "File requests" do
         it 'sends headers for content' do
           head "/v2/file/#{druid}/version/#{version_id}/image.jp2", params: { download: 'any' }
 
-          expect(response).to be_ok
-          headers = response.headers.transform_keys(&:downcase)
+          expect(response).to redirect_to %r{^http://stacks.stanford.edu:9000/stacks-test/bb/000/cr/7262/bb000cr7262/content/8ff299eda08d7c506273840d52a03bf3\?X-Amz-Algorithm=AWS4-HMAC-SHA256}
+
           expect(headers['accept-ranges']).to eq('bytes')
-          expect(headers['content-length']).to eq "12345"
-          expect(headers['content-disposition']).to include('attachment; filename="image.jp2"')
-          expect(headers['content-type']).to eq "image/jp2"
         end
-      end
-
-      context 'with a range header' do
-        it 'sends headers for content' do
-          head "/v2/file/#{druid}/version/#{version_id}/image.jp2", params: { download: 'any' }, headers: { 'Range' => 'bytes=0-' }
-
-          expect(response).to be_ok
-          headers = response.headers.transform_keys(&:downcase)
-          expect(headers['accept-ranges']).to eq('bytes')
-          expect(headers['content-length']).to eq "12345"
-          expect(headers['content-disposition']).to include('attachment; filename="image.jp2"')
-          expect(headers['content-type']).to eq "image/jp2"
-        end
-      end
-    end
-
-    describe 'GET file with range requests' do
-      before do
-        stub_request(:get, "https://purl.stanford.edu/#{druid}/version/#{version_id}.json")
-          .to_return(status: 200, body: public_json.to_json)
-      end
-
-      it 'returns 206 partial content for valid range request' do
-        get "/v2/file/#{druid}/version/#{version_id}/#{file_name}",
-            headers: { 'Range' => 'bytes=0-499' }
-
-        expect(response).to have_http_status(:partial_content)
-        expect(response.headers['Content-Range']).to eq('bytes 0-499/12345')
-        expect(response.headers['Content-Length']).to eq('500')
-        expect(response.headers['Accept-Ranges']).to eq('bytes')
-      end
-
-      it 'returns 206 partial content for suffix range request' do
-        get "/v2/file/#{druid}/version/#{version_id}/#{file_name}",
-            headers: { 'Range' => 'bytes=-1000' }
-
-        expect(response).to have_http_status(:partial_content)
-        expect(response.headers['Content-Range']).to eq('bytes 11345-12344/12345')
-        expect(response.headers['Content-Length']).to eq('1000')
-      end
-
-      it 'returns 206 partial content for prefix range request' do
-        get "/v2/file/#{druid}/version/#{version_id}/#{file_name}",
-            headers: { 'Range' => 'bytes=12000-' }
-
-        expect(response).to have_http_status(:partial_content)
-        expect(response.headers['Content-Range']).to eq('bytes 12000-12344/12345')
-        expect(response.headers['Content-Length']).to eq('345')
-      end
-
-      it 'returns 416 range not satisfiable for invalid range' do
-        get "/v2/file/#{druid}/version/#{version_id}/#{file_name}",
-            headers: { 'Range' => 'bytes=50000-60000' }
-
-        expect(response).to have_http_status(:range_not_satisfiable)
-        expect(response.headers['Content-Range']).to eq('bytes */12345')
-      end
-
-      it 'returns 416 range not satisfiable for malformed range' do
-        get "/v2/file/#{druid}/version/#{version_id}/#{file_name}",
-            headers: { 'Range' => 'bytes=invalid' }
-
-        expect(response).to have_http_status(:range_not_satisfiable)
-        expect(response.headers['Content-Range']).to eq('bytes */12345')
-      end
-
-      it 'returns full content when no range header is provided' do
-        get "/v2/file/#{druid}/version/#{version_id}/#{file_name}"
-
-        expect(response).to have_http_status(:ok)
-        expect(response.headers['Content-Length'].to_i).to be > 0
-        expect(response.headers['Accept-Ranges']).to eq('bytes')
-        expect(response.headers['Content-Range']).to be_nil
       end
     end
   end


### PR DESCRIPTION
This means that stacks doesn't have to proxy requests to s3, we can use a dedicated server like https://github.com/nginx/nginx-s3-gateway to be the proxy.