### PR TITLE
Don't report stream errors when the client disconnects

### DIFF
--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -74,12 +74,11 @@ class FileController < ApplicationController
       type: current_file.content_type,
       disposition:
     ) do |stream|
-      current_file.s3_range(range: range.s3_range) do |chunk|
-        stream.write(chunk)
+      handle_streaming_errors do
+        current_file.s3_range(range: range.s3_range) do |chunk|
+          stream.write(chunk)
+        end
       end
-    rescue StandardError => e
-      Honeybadger.notify(e)
-      raise
     end
   end
 
@@ -95,13 +94,31 @@ class FileController < ApplicationController
       type: current_file.content_type,
       disposition:
     ) do |stream|
-      current_file.s3_object do |chunk|
-        stream.write(chunk)
+      handle_streaming_errors do
+        current_file.s3_object do |chunk|
+          stream.write(chunk)
+        end
       end
-    rescue StandardError => e
-      Honeybadger.notify(e)
-      raise
     end
+  end
+
+  def handle_streaming_errors
+    yield
+  rescue StandardError => e
+    return if client_disconnected_error?(e)
+
+    Honeybadger.notify(e)
+    raise
+  end
+
+  def client_disconnected_error?(error)
+    return true if error.is_a?(ActionController::Live::ClientDisconnected)
+
+    [error.cause, original_error(error)].compact.any? { |nested_error| client_disconnected_error?(nested_error) }
+  end
+
+  def original_error(error)
+    error.original_error if error.respond_to?(:original_error)
   end
 
   def set_head_response_headers

--- a/spec/requests/file_spec.rb
+++ b/spec/requests/file_spec.rb
@@ -73,6 +73,39 @@ RSpec.describe "File requests" do
       end
     end
 
+    describe 'GET file streaming errors' do
+      let(:s3_client) { instance_double(Aws::S3::Client, head_object: s3_head) }
+      let(:s3_head) { instance_double(Aws::S3::Types::HeadObjectOutput, last_modified: Time.zone.now) }
+      let(:path) { "/v2/file/#{druid}/version/#{version_id}/#{file_name}" }
+
+      before do
+        stub_request(:get, "https://purl.stanford.edu/#{druid}/version/#{version_id}.json")
+          .to_return(status: 200, body: public_json.to_json)
+        allow(S3ClientFactory).to receive(:create_client).and_return(s3_client)
+        allow(Honeybadger).to receive(:notify)
+      end
+
+      it 'swallows S3 non-retryable streaming errors caused by client disconnects' do
+        client_disconnected_error = ActionController::Live::ClientDisconnected.new('client disconnected')
+        streaming_error = Aws::S3::Plugins::NonRetryableStreamingError.new(client_disconnected_error)
+        allow(s3_client).to receive(:get_object).and_raise(streaming_error)
+
+        expect { get path }.not_to raise_error
+
+        expect(response).to have_http_status(:ok)
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+
+      it 'reports S3 non-retryable streaming errors with other causes' do
+        streaming_error = Aws::S3::Plugins::NonRetryableStreamingError.new(StandardError.new('connection reset'))
+        allow(s3_client).to receive(:get_object).and_raise(streaming_error)
+
+        get path
+
+        expect(Honeybadger).to have_received(:notify).with(streaming_error)
+      end
+    end
+
     describe 'HEAD download file' do
       before do
         stub_request(:get, "https://purl.stanford.edu/#{druid}/version/#{version_id}.json")


### PR DESCRIPTION
Clients are allowed to disconnect and we don't need to hear about it